### PR TITLE
Add support for milliseconds in json dates

### DIFF
--- a/Fleece/Fleece.fs
+++ b/Fleece/Fleece.fs
@@ -160,7 +160,7 @@ module Fleece =
             | JString s ->
                 if s = null 
                     then Failure "Expected DateTime, got null"
-                    else match DateTime.TryParseExact(s, "yyyy-MM-ddTHH:mm:ssZ", null, DateTimeStyles.RoundtripKind) with
+                    else match DateTime.TryParseExact(s, [|"yyyy-MM-ddTHH:mm:ss.fffZ"; "yyyy-MM-ddTHH:mm:ssZ" |], null, DateTimeStyles.RoundtripKind) with
                          | true, t -> Success t
                          | _ -> Failure (sprintf "Invalid DateTime %s" s)
             | a -> failparse "DateTime" a
@@ -170,7 +170,7 @@ module Fleece =
             | JString s ->
                 if s = null 
                     then Failure "Expected DateTimeOffset, got null"
-                    else match DateTimeOffset.TryParseExact(s, "yyyy-MM-ddTHH:mm:ssK", null, DateTimeStyles.RoundtripKind) with
+                    else match DateTimeOffset.TryParseExact(s, [| "yyyy-MM-ddTHH:mm:ss.fffK"; "yyyy-MM-ddTHH:mm:ssK" |], null, DateTimeStyles.RoundtripKind) with
                          | true, t -> Success t
                          | _ -> Failure (sprintf "Invalid DateTimeOffset %s" s)
             | a -> failparse "DateTimeOffset" a
@@ -366,8 +366,8 @@ module Fleece =
         static member ToJSON (x: sbyte) = JsonPrimitive x :> JsonValue
         static member ToJSON (x: char) = JsonPrimitive x :> JsonValue
         static member ToJSON (x: Guid) = JsonPrimitive x :> JsonValue
-        static member ToJSON (x: DateTime) = JString (x.ToString("yyyy-MM-ddTHH:mm:ssZ")) // JsonPrimitive is incorrect for DateTime
-        static member ToJSON (x: DateTimeOffset) = JString (x.ToString("yyyy-MM-ddTHH:mm:ssK")) // JsonPrimitive is incorrect for DateTimeOffset
+        static member ToJSON (x: DateTime) = JString (x.ToString("yyyy-MM-ddTHH:mm:ss.fffZ")) // JsonPrimitive is incorrect for DateTime
+        static member ToJSON (x: DateTimeOffset) = JString (x.ToString("yyyy-MM-ddTHH:mm:ss.fffK")) // JsonPrimitive is incorrect for DateTimeOffset
 
     /// Maps a value to JSON
     let inline toJSON (x: 'a) : JsonValue = iToJSON (ToJSONClass, x)

--- a/Tests/Tests.fs
+++ b/Tests/Tests.fs
@@ -168,6 +168,18 @@ let tests =
                       ] }
                 Assert.Equal("Person", Success expectedPerson, actual)
             }
+
+            test "DateTime with milliseconds" {
+                let actual : DateTime ParseResult = fromJSON (JsonPrimitive "2014-09-05T04:38:07.862Z")
+                let expected = new DateTime(2014,9,5,4,38,7,862)
+                Assert.Equal("DateTime", Success expected, actual)
+            }
+
+            test "DateTime without milliseconds" {
+                let actual : DateTime ParseResult = fromJSON (JsonPrimitive "2014-09-05T04:38:07Z")
+                let expected = new DateTime(2014,9,5,4,38,7)
+                Assert.Equal("DateTime", Success expected, actual)
+            }
         ]
 
         testList "To JSON" [
@@ -180,11 +192,19 @@ let tests =
             }
 
             test "DateTime" {
-                Assert.JSON("\"2000-03-01T16:23:34Z\"", DateTime(2000, 3, 1, 16, 23, 34))
+                Assert.JSON("\"2000-03-01T16:23:34.000Z\"", DateTime(2000, 3, 1, 16, 23, 34))
+            }
+
+            test "DateTime with milliseconds" {
+                Assert.JSON("\"2000-03-01T16:23:34.123Z\"", DateTime(2000, 3, 1, 16, 23, 34, 123))
             }
 
             test "DateTimeOffset" {
-                Assert.JSON("\"2000-03-01T16:23:34+03:00\"", DateTimeOffset(2000, 3, 1, 16, 23, 34, TimeSpan(3, 0, 0)))
+                Assert.JSON("\"2000-03-01T16:23:34.000+03:00\"", DateTimeOffset(2000, 3, 1, 16, 23, 34, TimeSpan(3, 0, 0)))
+            }
+
+            test "DateTimeOffset with milliseconds" {
+                Assert.JSON("\"2000-03-01T16:23:34.078+03:00\"", DateTimeOffset(2000, 3, 1, 16, 23, 34, 78, TimeSpan(3, 0, 0)))
             }
 
             test "Person" {


### PR DESCRIPTION
- toJSON now includes milliseconds when converting dates, using
  the format "yyyy-MM-ddThh:mm:ss.fffZ". (3 decimal points on seconds
  seems standard)
- fromJSON supports dates with and without milliseconds
- updated DateTimeOffset conversion similarly

*\* The current master doesn't build on my machine, so I needed to develop with an altered fsproj, then cherry-pick just these bits of the change. Please confirm it builds and passes tests on your setup. :) ***
