### PR TITLE
Added parsing of datetime when using newtonsoft.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ packages/*
 
 docsrc/content/license.md
 docsrc/content/release-notes.md
+*.user

--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -121,24 +121,25 @@ module Newtonsoft =
     type JsonObject = JObject
     
     type private JsonHelpers () =
-        static member create (x: decimal) = JValue          x  :> JToken
-        static member create (x: Double ) = JValue          x  :> JToken
-        static member create (x: Single ) = JValue          x  :> JToken
-        static member create (x: int    ) = JValue          x  :> JToken
-        static member create (x: uint32 ) = JValue          x  :> JToken
-        static member create (x: int64  ) = JValue          x  :> JToken
-        static member create (x: uint64 ) = JValue          x  :> JToken
-        static member create (x: int16  ) = JValue          x  :> JToken
-        static member create (x: uint16 ) = JValue          x  :> JToken
-        static member create (x: byte   ) = JValue          x  :> JToken
-        static member create (x: sbyte  ) = JValue          x  :> JToken
-        static member create (x: char   ) = JValue (string  x) :> JToken
-        static member create (x: Guid   ) = JValue (string  x) :> JToken
+        static member create (x: decimal)  = JValue          x  :> JToken
+        static member create (x: Double )  = JValue          x  :> JToken
+        static member create (x: Single )  = JValue          x  :> JToken
+        static member create (x: int    )  = JValue          x  :> JToken
+        static member create (x: uint32 )  = JValue          x  :> JToken
+        static member create (x: int64  )  = JValue          x  :> JToken
+        static member create (x: uint64 )  = JValue          x  :> JToken
+        static member create (x: int16  )  = JValue          x  :> JToken
+        static member create (x: uint16 )  = JValue          x  :> JToken
+        static member create (x: byte   )  = JValue          x  :> JToken
+        static member create (x: sbyte  )  = JValue          x  :> JToken
+        static member create (x: char   )  = JValue (string  x) :> JToken
+        static member create (x: Guid   )  = JValue (string  x) :> JToken
+        static member create (x: DateTime) = JValue           x :> JToken
 
 
     // FSharp.Newtonsoft.Json AST adapter
 
-    let (|JArray|JObject|JNumber|JBool|JString|JNull|) (o: JToken) =
+    let (|JArray|JObject|JNumber|JBool|JString|JNull|JDate|) (o: JToken) =
         match o.Type with
         | JTokenType.Null    -> JNull
         | JTokenType.Array   -> JArray ((o :?> JArray) |> IList.toIReadOnlyList)
@@ -147,6 +148,7 @@ module Newtonsoft =
         | JTokenType.Float   -> JNumber  o
         | JTokenType.Boolean -> JBool   (o.ToObject () : bool)
         | JTokenType.String  -> JString (o.ToObject () : string)
+        | JTokenType.Date    -> JDate    o
         | t                  -> failwithf "Invalid JTokenType %A" t
     
     let dictAsProps (x: IReadOnlyDictionary<string, JToken>) = x |> Seq.map (|KeyValue|) |> Array.ofSeq
@@ -161,6 +163,7 @@ module Newtonsoft =
     let inline JNumber (x: decimal) = JValue x :> JToken
     let JNull = JValue.CreateNull () :> JToken
     let inline JString (x: string) = if isNull x then JNull else JValue x :> JToken
+    let inline JDate (x: DateTime) = JValue x :> JToken
     
 #endif
 
@@ -333,6 +336,7 @@ module SystemTextJson =
         | String = 4
         | Bool   = 5
         | Null   = 6
+        | Date   = 7
 
     let getJType (o: JsonValue) =
         match o with
@@ -342,6 +346,9 @@ module SystemTextJson =
         | JNumber _ -> JType.Number
         | JBool _   -> JType.Bool
         | JString _ -> JType.String
+#if NEWTONSOFT
+        | JDate _   -> JType.Date
+#endif
 
     type DecodeError =
         | JsonTypeMismatch of System.Type * JsonValue * JType * JType
@@ -691,6 +698,20 @@ module SystemTextJson =
             | JString s    -> tryParse<Guid> s |> Operators.option Success (Decode.Fail.invalidValue x "")
             | a -> Decode.Fail.strExpected a
 
+#if NEWTONSOFT
+        let dateTime x =
+            match x with
+            | JString null
+            | JDate null -> Decode.Fail.nullString
+            | JString s -> 
+                match DateTime.TryParseExact (s, [| "yyyy-MM-ddTHH:mm:ss.fffZ"; "yyyy-MM-ddTHH:mm:ssZ" |], null, DateTimeStyles.RoundtripKind) with
+                | true, t -> Success t
+                | _       -> Decode.Fail.invalidValue x ""
+            | JDate d    ->
+                Success <| d.Value<DateTime>()
+            | a -> Decode.Fail.strExpected a
+
+#else
         let dateTime x =
             match x with
             | JString null -> Decode.Fail.nullString
@@ -699,6 +720,7 @@ module SystemTextJson =
                 | true, t -> Success t
                 | _       -> Decode.Fail.invalidValue x ""
             | a -> Decode.Fail.strExpected a
+#endif
 
         let dateTimeOffset x =
             match x with

--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -336,7 +336,9 @@ module SystemTextJson =
         | String = 4
         | Bool   = 5
         | Null   = 6
+#if NEWTONSOFT
         | Date   = 7
+#endif
 
     let getJType (o: JsonValue) =
         match o with

--- a/test/Tests/Tests.fs
+++ b/test/Tests/Tests.fs
@@ -391,15 +391,15 @@ let tests = [
                 Assert.JSON(expected, p)
                 #endif
                 #if FSHARPDATA
-                let expected = """{"name":"John","age":44,"gender":"Male","children":[{"name":"Katy","age":5,"gender":"Female","children":[]},{"name":"Johnny","age":7,"gender":"Male","children":[]}]}"""
+                let expected = """{"name":"John","age":44,"gender":"Male","dob":"1975-01-01T00:00:00.000Z","children":[{"name":"Katy","age":5,"gender":"Female","dob":"1975-01-01T00:00:00.000Z","children":[]},{"name":"Johnny","age":7,"gender":"Male","dob":"1975-01-01T00:00:00.000Z","children":[]}]}"""
                 Assert.JSON(expected, p)
                 #endif
                 #if SYSTEMJSON
-                let expected = """{"age":44,"children":[{"age":5,"children":[],"gender":"Female","name":"Katy"},{"age":7,"children":[],"gender":"Male","name":"Johnny"}],"gender":"Male","name":"John"}"""
+                let expected = """{"age":44,"children":[{"age":5,"children":[],"dob":"1975-01-01T00:00:00.000Z","gender":"Female","name":"Katy"},{"age":7,"children":[],"dob":"1975-01-01T00:00:00.000Z","gender":"Male","name":"Johnny"}],"dob":"1975-01-01T00:00:00.000Z","gender":"Male","name":"John"}"""
                 Assert.JSON(expected, p)
                 #endif
                 #if SYSTEMTEXTJSON
-                let expected = """{"name":"John","age":44,"gender":"Male","children":[{"name":"Katy","age":5,"gender":"Female","children":[]},{"name":"Johnny","age":7,"gender":"Male","children":[]}]}"""
+                let expected = """{"name":"John","age":44,"gender":"Male","dob":"1975-01-01T00:00:00.000Z","children":[{"name":"Katy","age":5,"gender":"Female","dob":"1975-01-01T00:00:00.000Z","children":[]},{"name":"Johnny","age":7,"gender":"Male","dob":"1975-01-01T00:00:00.000Z","children":[]}]}"""
                 Assert.JSON(expected, p)
                 #endif
             }

--- a/test/Tests/Tests.fs
+++ b/test/Tests/Tests.fs
@@ -564,7 +564,7 @@ let tests = [
             //yield testProperty "float32" (roundtrip<float32>)  // not handled by FsCheck
             yield testProperty "string" (roundtrip<string>)
             yield testProperty "decimal" (roundtrip<decimal>)
-            //yield testProperty "DateTime" (roundtrip<DateTime>)
+            yield testProperty "DateTime" (roundtrip<DateTime>)
             yield testProperty "DateTimeOffset" (roundtrip<DateTimeOffset>)
             yield testProperty "char" (roundtrip<char>)
             yield testProperty "byte" (roundtrip<byte>)

--- a/test/Tests/Tests.fs
+++ b/test/Tests/Tests.fs
@@ -29,6 +29,7 @@ open Newtonsoft.Json
 open Fleece.Newtonsoft.Helpers
 open Fleece.Newtonsoft
 open Fleece.Newtonsoft.Operators
+
 #endif
 let (|Success|Failure|) =
     function
@@ -44,15 +45,16 @@ type Person = {
     Name: string
     Age: int
     Gender: Gender
+    DoB: DateTime
     Children: Person list
 }
 
 type Person with
-    static member Create name age gender children = { Person.Name = name; Age = age; Gender = gender; Children = children }
+    static member Create name age dob gender children = { Person.Name = name; Age = age; DoB = dob; Gender = gender; Children = children }
 
     static member OfJson json = 
         match json with
-        | JObject o -> Person.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "gender") <*> (o .@ "children")
+        | JObject o -> Person.Create <!> (o .@ "name") <*> (o .@ "age") <*> (o .@ "dob") <*> (o .@ "gender") <*> (o .@ "children")
         | x -> Decode.Fail.objExpected x
 
     static member ToJson (x: Person) =
@@ -60,6 +62,7 @@ type Person with
             "name" .= x.Name
             "age" .= x.Age
             "gender" .= x.Gender
+            "dob" .= x.DoB
             "children" .= x.Children
         ] 
 
@@ -223,19 +226,22 @@ let tests = [
             }
 
             test "Person recursive" {
-                let actual : Person ParseResult = parseJson """{"name": "John", "age": 44, "gender": "Male", "children": [{"name": "Katy", "age": 5, "gender": "Female", "children": []}, {"name": "Johnny", "age": 7, "gender": "Male", "children": []}]}"""
+                let actual : Person ParseResult = parseJson """{"name": "John", "age": 44, "dob": "1975-01-01T00:00:00.000Z", "gender": "Male", "children": [{"name": "Katy", "age": 5, "dob": "1975-01-01T00:00:00.000Z", "gender": "Female", "children": []}, {"name": "Johnny", "age": 7, "dob": "1975-01-01T00:00:00.000Z","gender": "Male", "children": []}]}"""
                 let expectedPerson = 
                     { Person.Name = "John"
                       Age = 44
+                      DoB = DateTime(1975, 01, 01)
                       Gender = Gender.Male
                       Children = 
                       [
                         { Person.Name = "Katy"
                           Age = 5
+                          DoB = DateTime(1975, 01, 01)
                           Gender = Gender.Female
                           Children = [] }
                         { Person.Name = "Johnny"
                           Age = 7
+                          DoB = DateTime(1975, 01, 01)
                           Gender = Gender.Male
                           Children = [] }
                       ] }
@@ -365,20 +371,23 @@ let tests = [
                 let p = 
                     { Person.Name = "John"
                       Age = 44
+                      DoB = DateTime(1975, 01, 01)
                       Gender = Gender.Male
                       Children = 
                       [
                         { Person.Name = "Katy"
                           Age = 5
+                          DoB = DateTime(1975, 01, 01)
                           Gender = Gender.Female
                           Children = [] }
                         { Person.Name = "Johnny"
                           Age = 7
+                          DoB = DateTime(1975, 01, 01)
                           Gender = Gender.Male
                           Children = [] }
                       ] }
                 #if NEWTONSOFT
-                let expected = """{"name":"John","age":44,"gender":"Male","children":[{"name":"Katy","age":5,"gender":"Female","children":[]},{"name":"Johnny","age":7,"gender":"Male","children":[]}]}"""
+                let expected = """{"name":"John","age":44,"gender":"Male","dob":"1975-01-01T00:00:00.000Z","children":[{"name":"Katy","age":5,"gender":"Female","dob":"1975-01-01T00:00:00.000Z","children":[]},{"name":"Johnny","age":7,"gender":"Male","dob":"1975-01-01T00:00:00.000Z","children":[]}]}"""
                 Assert.JSON(expected, p)
                 #endif
                 #if FSHARPDATA
@@ -555,7 +564,7 @@ let tests = [
             //yield testProperty "float32" (roundtrip<float32>)  // not handled by FsCheck
             yield testProperty "string" (roundtrip<string>)
             yield testProperty "decimal" (roundtrip<decimal>)
-            yield testProperty "DateTime" (roundtrip<DateTime>)
+            //yield testProperty "DateTime" (roundtrip<DateTime>)
             yield testProperty "DateTimeOffset" (roundtrip<DateTimeOffset>)
             yield testProperty "char" (roundtrip<char>)
             yield testProperty "byte" (roundtrip<byte>)
@@ -610,4 +619,5 @@ let main _ =
                                         printf "."
                                     })
 *)
+
     runParallel (TestList (tests @ Lenses.tests))


### PR DESCRIPTION
When using Newtonsoft.Json and trying to parse an object containing a date time, it would fail with an exception "Invalid JToken type".

This PR fixes that behavior.

