### PR TITLE
Fixed float parsing for infinities and NaN

### DIFF
--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -445,6 +445,11 @@ module SystemTextJson =
                   Success (j.ToObject<'a> ())
                 with
                 | e -> Decode.Fail.invalidValue j (string e)
+            | JString _ -> 
+                try
+                    Success (x.ToObject<'a> ())
+                with
+                | e -> Decode.Fail.invalidValue x (string e)
             | js -> Decode.Fail.numExpected js
 
         type JsonHelpers with


### PR DESCRIPTION
Fleece didn't handle all floats whose values were Infinity or Nan. The test for floats was actually commented out, but mentioning NaN equality.
This PR fixes this behavior for fleece and brought back the float parsing test by providing a specific function to be able to compare NaN and Infinity. The changes were mostly for Newtonsoft.Json. System.Net.Json doesn't even handle these "special" floats (throws exception) and other libraries seem to be working, if we trust in fscheck :-)