### PR TITLE
Remove requirement for mono for non Windows platforms

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: 3.1.405
     - name: Install dependencies
       run: dotnet restore
     - name: Build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,42 +1,27 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-      <RepositoryUrl>https://github.com/fsprojects/Fleece</RepositoryUrl>
-      <PackageProjectUrl>https://github.com/fsprojects/Fleece</PackageProjectUrl>
-      <Authors>Mauricio Scheffer,Lev Gorodinski,Oskar Gewalli, Gustavo P. Leon</Authors>
-      <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-      <PackageTags>json fsharp</PackageTags>
+    <PropertyGroup>
+        <RepositoryUrl>https://github.com/fsprojects/Fleece</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/fsprojects/Fleece</PackageProjectUrl>
+        <Authors>Mauricio Scheffer,Lev Gorodinski,Oskar Gewalli, Gustavo P. Leon</Authors>
+        <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+        <PackageTags>json fsharp</PackageTags>
 
-      <WarningLevel>3</WarningLevel>
+        <WarningLevel>3</WarningLevel>
 
-      <VersionPrefix>0.8.0</VersionPrefix>
-      <VersionSuffix></VersionSuffix>
-      <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
-      <Version Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</Version>
-      <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
-      <FileVersion>$(VersionPrefix).0</FileVersion>
-  </PropertyGroup>
+        <VersionPrefix>0.8.0</VersionPrefix>
+        <VersionSuffix></VersionSuffix>
+        <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
+        <Version Condition=" '$(VersionSuffix)' == '' ">$(VersionPrefix)</Version>
+        <AssemblyVersion>$(VersionPrefix).0</AssemblyVersion>
+        <FileVersion>$(VersionPrefix).0</FileVersion>
+    </PropertyGroup>
 
-  <!-- mono -->
-  <PropertyGroup Condition="'$(OS)' == 'Unix'">
-    <MonoRoot Condition="'$(MonoRoot)' == '' and $([MSBuild]::IsOsPlatform('Linux'))">/usr</MonoRoot>
-    <MonoRoot Condition="'$(MonoRoot)' == '' and $([MSBuild]::IsOsPlatform('OSX'))">/Library/Frameworks/Mono.framework/Versions/Current</MonoRoot>
-    <MonoLibFolder>$(MonoRoot)/lib/mono</MonoLibFolder>
-    <MonoPackaging Condition="$(TargetFramework.StartsWith('net4'))">true</MonoPackaging>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net45'">$(MonoLibFolder)/4.5-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net451'">$(MonoLibFolder)/4.5.1-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net452'">$(MonoLibFolder)/4.5.2-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net46'">$(MonoLibFolder)/4.6-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net461'">$(MonoLibFolder)/4.6.1-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net462'">$(MonoLibFolder)/4.6.2-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net47'">$(MonoLibFolder)/4.7-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net471'">$(MonoLibFolder)/4.7.1-api</FrameworkPathOverride>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net472'">$(MonoLibFolder)/4.7.2-api</FrameworkPathOverride>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ build_script:
   - cmd: build.bat
 test_script:
   - cmd: dotnet run -p .\test\Tests.SystemJson\Tests.SystemJson.fsproj -c Release -f net461
-  - cmd: dotnet run -p .\test\Tests.FSharpData\Tests.FSharpData.fsproj -c Release -f net461
-  - cmd: dotnet run -p .\test\Tests.NewtonsoftJson\Tests.NewtonsoftJson.fsproj -c Release -f net461
+  - cmd: dotnet run -p .\test\Tests.FSharpData\Tests.FSharpData.fsproj -c Release -f netcoreapp3.1
+  - cmd: dotnet run -p .\test\Tests.NewtonsoftJson\Tests.NewtonsoftJson.fsproj -c Release -f netcoreapp3.1
   - cmd: dotnet run -p .\test\Tests.SystemTextJson\Tests.SystemTextJson.fsproj -c Release -f netcoreapp3.1
 
 artifacts:

--- a/docsrc/content/codec.fsx
+++ b/docsrc/content/codec.fsx
@@ -1,9 +1,9 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/System.Json.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/Fleece.SystemJson.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/FSharpPlus.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/System.Json.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/Fleece.SystemJson.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/FSharpPlus.dll"
 
 open System.Json
 open Fleece.SystemJson
@@ -12,14 +12,14 @@ open Fleece.SystemJson.Operators
 (**
 ## CODEC
 
-For types that deserialize to Json Objets, typically (but not limited to) records, you can alternatively use codecs and have a single method which maps between fields and values. 
+For types that deserialize to Json Objets, typically (but not limited to) records, you can alternatively use codecs and have a single method which maps between fields and values.
 
 *)
 
-type Person = { 
+type Person = {
     name : string * string
     age : int option
-    children: Person list } 
+    children: Person list }
     with
     static member JsonObjCodec =
         fun f l a c -> { name = (f, l); age = a; children = c }
@@ -47,7 +47,7 @@ let john = parseJson<Person> """{
 If you prefer you can write the same with functions:
 *)
 
-type PersonF = { 
+type PersonF = {
     name : string * string
     age : int option
     children: PersonF list }
@@ -68,7 +68,7 @@ type Shape =
     | Rectangle of width : float * length : float
     | Circle of radius : float
     | Prism of width : float * float * height : float
-    with 
+    with
         static member JsonObjCodec =
             Rectangle <!> jreq "rectangle" (function Rectangle (x, y) -> Some (x, y) | _ -> None)
             <|> ( Circle <!> jreq "radius" (function Circle x -> Some x | _ -> None) )
@@ -81,7 +81,7 @@ type ShapeC =
     | Rectangle of width : float * length : float
     | Circle of radius : float
     | Prism of width : float * float * height : float
-    with 
+    with
         static member JsonObjCodec =
             jchoice
                 [

--- a/docsrc/content/combinators.fsx
+++ b/docsrc/content/combinators.fsx
@@ -1,9 +1,9 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/System.Json.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/Fleece.SystemJson.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/FSharpPlus.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/System.Json.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/Fleece.SystemJson.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/FSharpPlus.dll"
 
 open System.Json
 open Fleece.SystemJson
@@ -41,7 +41,7 @@ let colorEncoder = function
     | White -> JString "white"
 
 let colorCodec = colorDecoder, colorEncoder
-    
+
 let [<GeneralizableValue>]carCodec<'t> =
     fun i c k -> { Id = i; Color = c; Kms = k }
     |> withFields

--- a/docsrc/content/comparison-with-json-net.fsx
+++ b/docsrc/content/comparison-with-json-net.fsx
@@ -1,9 +1,9 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/Fleece.NewtonsoftJson/bin/Release/net461/Newtonsoft.Json.dll"
-#r @"../../src/Fleece.NewtonsoftJson/bin/Release/net461/Fleece.NewtonsoftJson.dll"
-#r @"../../src/Fleece.NewtonsoftJson/bin/Release/net461/FSharpPlus.dll"
+#r @"../../src/Fleece.NewtonsoftJson/bin/Release/netstandard2.1/Newtonsoft.Json.dll"
+#r @"../../src/Fleece.NewtonsoftJson/bin/Release/netstandard2.1/Fleece.NewtonsoftJson.dll"
+#r @"../../src/Fleece.NewtonsoftJson/bin/Release/netstandard2.1/FSharpPlus.dll"
 
 open System
 open Newtonsoft.Json
@@ -86,12 +86,12 @@ It's easy to let the structure of your Json be completely independent of the str
 If we look at a simple example of the Json not matching the representation (where you would need a custom JsonConverter):
 *)
 
-type Person = { 
+type Person = {
     Name : string * string
 }
 with
     static member ToJson (x: Person) =
-        jobj [ 
+        jobj [
             "firstname" .= fst x.Name
             "lastname" .= snd x.Name
         ]

--- a/docsrc/content/giraffe.fsx
+++ b/docsrc/content/giraffe.fsx
@@ -1,9 +1,9 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/System.Json.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/Fleece.SystemJson.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/FSharpPlus.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/System.Json.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/Fleece.SystemJson.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/FSharpPlus.dll"
 #r @"../../packages/docs/TaskBuilder.fs/lib/net46/TaskBuilder.fs.dll"
 
 module Giraffe=

--- a/docsrc/content/suave.fsx
+++ b/docsrc/content/suave.fsx
@@ -1,10 +1,10 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/System.Json.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/Fleece.SystemJson.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/FSharpPlus.dll"
-#r @"../../packages/docs/Suave/lib/net461/Suave.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/System.Json.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/Fleece.SystemJson.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/FSharpPlus.dll"
+#r @"../../packages/docs/Suave/lib/netstandard2.1/Suave.dll"
 
 
 (**

--- a/docsrc/content/to-json-and-of-json.fsx
+++ b/docsrc/content/to-json-and-of-json.fsx
@@ -1,17 +1,17 @@
 (*** hide ***)
-// This block of code is omitted in the generated HTML documentation. Use 
+// This block of code is omitted in the generated HTML documentation. Use
 // it to define helpers that you do not want to show in the documentation.
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/System.Json.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/Fleece.SystemJson.dll"
-#r @"../../src/Fleece.SystemJson/bin/Release/net461/FSharpPlus.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/System.Json.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/Fleece.SystemJson.dll"
+#r @"../../src/Fleece.SystemJson/bin/Release/netstandard2.1/FSharpPlus.dll"
 
 open System.Json
 open Fleece.SystemJson
 open Fleece.SystemJson.Operators
 #if FSHARPDATA
-#r @"../../src/Fleece.FSharpData/bin/Release/net461/FSharp.Data.dll"
-#r @"../../src/Fleece.FSharpData/bin/Release/net461/Fleece.FSharpData.dll"
-#r @"../../src/Fleece.FSharpData/bin/Release/net461/FSharpPlus.dll"
+#r @"../../src/Fleece.FSharpData/bin/Release/netstandard2.1/FSharp.Data.dll"
+#r @"../../src/Fleece.FSharpData/bin/Release/netstandard2.1/Fleece.FSharpData.dll"
+#r @"../../src/Fleece.FSharpData/bin/Release/netstandard2.1/FSharpPlus.dll"
 
 open FSharp.Data
 open Fleece.FSharpData
@@ -39,16 +39,16 @@ You can map it to JSON like this:
 
 type Person with
     static member ToJson (x: Person) =
-        jobj [ 
+        jobj [
             "name" .= x.Name
             "age" .= x.Age
             "children" .= x.Children
         ]
 
-let p = 
+let p =
     { Person.Name = "John"
       Age = 44
-      Children = 
+      Children =
       [
         { Person.Name = "Katy"
           Age = 5
@@ -80,7 +80,7 @@ type Person with
                 }
             | x -> Error <| Uncategorized (sprintf "Error parsing person: %A" x)
         | x -> Decode.Fail.objExpected x
-        
+
 let john : Person ParseResult = parseJson """{
     "name": "John",
     "age": 44,
@@ -129,7 +129,7 @@ type PersonM = {
 type PersonM with
     static member OfJson json =
         match json with
-        | JObject o -> 
+        | JObject o ->
             monad {
                 let! name = o .@ "name"
                 let! age = o .@ "age"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
-  "sdk": {
-    "version": "3.0.103",
-    "rollForward": "latestMinor"
-  }
+    "sdk": {
+        "version": "3.1.405",
+        "rollForward": "latestMinor"
+    }
 }

--- a/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
@@ -15,9 +15,5 @@
         <PackageReference Update="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharpPlus" Version="1.1.1" />
         <PackageReference Include="FSharp.Data" Version="3.0.0" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 </Project>

--- a/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <NoWarn>0686</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Description>JSON mapper for FSharp.Data</Description>

--- a/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <NoWarn>0686</NoWarn>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Description>JSON mapper for FSharp.Data</Description>
-    <DefineConstants>FSHARPDATA;$(DefineConstants)</DefineConstants>
-    <OtherFlags>--warnon:1182</OtherFlags>    
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="../Fleece/Fleece.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharpPlus" Version="1.1.1" />
-    <PackageReference Include="FSharp.Data" Version="3.0.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.1</TargetFrameworks>
+        <NoWarn>0686</NoWarn>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Description>JSON mapper for FSharp.Data</Description>
+        <DefineConstants>FSHARPDATA;$(DefineConstants)</DefineConstants>
+        <OtherFlags>--warnon:1182</OtherFlags>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="../Fleece/Fleece.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="FSharpPlus" Version="1.1.1" />
+        <PackageReference Include="FSharp.Data" Version="3.0.0" />
+    </ItemGroup>
 </Project>

--- a/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
@@ -15,5 +15,9 @@
         <PackageReference Update="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharpPlus" Version="1.1.1" />
         <PackageReference Include="FSharp.Data" Version="3.0.0" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 </Project>

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
@@ -15,9 +15,5 @@
         <PackageReference Update="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharpPlus" Version="1.1.1" />
         <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 </Project>

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <NoWarn>0686</NoWarn>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Description>JSON mapper for Newtonsoft Json</Description>
-    <DefineConstants>NEWTONSOFT;$(DefineConstants)</DefineConstants>
-    <OtherFlags>--warnon:1182</OtherFlags>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="../Fleece/Fleece.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharpPlus" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.1</TargetFrameworks>
+        <NoWarn>0686</NoWarn>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Description>JSON mapper for Newtonsoft Json</Description>
+        <DefineConstants>NEWTONSOFT;$(DefineConstants)</DefineConstants>
+        <OtherFlags>--warnon:1182</OtherFlags>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="../Fleece/Fleece.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="FSharpPlus" Version="1.1.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    </ItemGroup>
 </Project>

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <NoWarn>0686</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Description>JSON mapper for Newtonsoft Json</Description>

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
@@ -15,5 +15,9 @@
         <PackageReference Update="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharpPlus" Version="1.1.1" />
         <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 </Project>

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
@@ -15,9 +15,5 @@
         <PackageReference Update="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharpPlus" Version="1.1.1" />
         <PackageReference Include="System.Json" Version="4.7.1" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 </Project>

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;net461</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
         <NoWarn>0686</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Description>JSON mapper for System.Json</Description>

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.1;net461</TargetFrameworks>
         <NoWarn>0686</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Description>JSON mapper for System.Json</Description>

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
@@ -14,6 +14,6 @@
     <ItemGroup>
         <PackageReference Update="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharpPlus" Version="1.1.1" />
-        <PackageReference Include="System.Json" Version="4.5.0" />
+        <PackageReference Include="System.Json" Version="4.7.1" />
     </ItemGroup>
 </Project>

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
@@ -15,5 +15,9 @@
         <PackageReference Update="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharpPlus" Version="1.1.1" />
         <PackageReference Include="System.Json" Version="4.7.1" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 </Project>

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <NoWarn>0686</NoWarn>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Description>JSON mapper for System.Json</Description>
-    <DefineConstants>SYSTEMJSON;$(DefineConstants)</DefineConstants>
-    <OtherFlags>--warnon:1182</OtherFlags>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="../Fleece/Fleece.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharpPlus" Version="1.1.1" />
-    <PackageReference Include="System.Json" Version="4.5.0" />
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.1</TargetFrameworks>
+        <NoWarn>0686</NoWarn>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Description>JSON mapper for System.Json</Description>
+        <DefineConstants>SYSTEMJSON;$(DefineConstants)</DefineConstants>
+        <OtherFlags>--warnon:1182</OtherFlags>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="../Fleece/Fleece.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="FSharpPlus" Version="1.1.1" />
+        <PackageReference Include="System.Json" Version="4.5.0" />
+    </ItemGroup>
 </Project>

--- a/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
+++ b/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
@@ -15,9 +15,5 @@
         <PackageReference Update="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharpPlus" Version="1.1.1" />
         <PackageReference Include="System.Text.Json" Version="4.7.1" />
-        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-        </PackageReference>
     </ItemGroup>
 </Project>

--- a/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
+++ b/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
         <NoWarn>0686</NoWarn>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Description>JSON mapper for System.Text.Json</Description>

--- a/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
+++ b/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
@@ -1,18 +1,19 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <NoWarn>0686</NoWarn>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Description>JSON mapper for System.Text.Json</Description>
-    <DefineConstants>SYSTEMTEXTJSON;$(DefineConstants)</DefineConstants>
-    <OtherFlags>--warnon:1182</OtherFlags>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="../Fleece/Fleece.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FSharpPlus" Version="1.1.1" />
-    <PackageReference Include="System.Text.Json" Version="4.7.1" />
-  </ItemGroup>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.1</TargetFrameworks>
+        <NoWarn>0686</NoWarn>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Description>JSON mapper for System.Text.Json</Description>
+        <DefineConstants>SYSTEMTEXTJSON;$(DefineConstants)</DefineConstants>
+        <OtherFlags>--warnon:1182</OtherFlags>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="../Fleece/Fleece.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="FSharpPlus" Version="1.1.1" />
+        <PackageReference Include="System.Text.Json" Version="4.7.1" />
+    </ItemGroup>
 </Project>

--- a/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
+++ b/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
@@ -15,5 +15,9 @@
         <PackageReference Update="FSharp.Core" Version="4.6.2" />
         <PackageReference Include="FSharpPlus" Version="1.1.1" />
         <PackageReference Include="System.Text.Json" Version="4.7.1" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 </Project>

--- a/test/IntegrationCompilationTests/IntegrationCompilationTests.fsproj
+++ b/test/IntegrationCompilationTests/IntegrationCompilationTests.fsproj
@@ -1,18 +1,19 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="Library.fs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="Library.fs" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <ProjectReference Include="..\..\src\Fleece.SystemJson\Fleece.SystemJson.fsproj" />
-    <ProjectReference Include="..\..\src\Fleece.FSharpData\Fleece.FSharpData.fsproj" />
-    <ProjectReference Include="..\..\src\Fleece.NewtonsoftJson\Fleece.NewtonsoftJson.fsproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <ProjectReference Include="..\..\src\Fleece.SystemJson\Fleece.SystemJson.fsproj" />
+        <ProjectReference Include="..\..\src\Fleece.FSharpData\Fleece.FSharpData.fsproj" />
+        <ProjectReference Include="..\..\src\Fleece.NewtonsoftJson\Fleece.NewtonsoftJson.fsproj" />
+    </ItemGroup>
 
 </Project>

--- a/test/Tests.FSharpData/Tests.FSharpData.fsproj
+++ b/test/Tests.FSharpData/Tests.FSharpData.fsproj
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>    
-    <DefineConstants>FSHARPDATA;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="../Tests/Lenses.fs" />
-    <Compile Include="../Tests/Tests.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FsCheck" Version="2.14.2" />
-    <PackageReference Include="Fuchu" Version="1.1.0" />
-    <PackageReference Include="Fuchu.FsCheck" Version="1.1.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Fleece.FSharpData\Fleece.FSharpData.fsproj" />
-  </ItemGroup>
-  
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <DefineConstants>FSHARPDATA;$(DefineConstants)</DefineConstants>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="../Tests/Lenses.fs" />
+        <Compile Include="../Tests/Tests.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="FsCheck" Version="2.14.2" />
+        <PackageReference Include="Fuchu" Version="1.1.0" />
+        <PackageReference Include="Fuchu.FsCheck" Version="1.1.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Fleece.FSharpData\Fleece.FSharpData.fsproj" />
+    </ItemGroup>
+
 </Project>

--- a/test/Tests.NewtonsoftJson/Tests.NewtonsoftJson.fsproj
+++ b/test/Tests.NewtonsoftJson/Tests.NewtonsoftJson.fsproj
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>    
-    <DefineConstants>NEWTONSOFT;$(DefineConstants)</DefineConstants>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="../Tests/Lenses.fs" />
-    <Compile Include="../Tests/Tests.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FsCheck" Version="2.14.2" />
-    <PackageReference Include="Fuchu" Version="1.1.0" />
-    <PackageReference Include="Fuchu.FsCheck" Version="1.1.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Fleece.NewtonsoftJson\Fleece.NewtonsoftJson.fsproj" />
-  </ItemGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <DefineConstants>NEWTONSOFT;$(DefineConstants)</DefineConstants>
+        <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="../Tests/Lenses.fs" />
+        <Compile Include="../Tests/Tests.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="FsCheck" Version="2.14.2" />
+        <PackageReference Include="Fuchu" Version="1.1.0" />
+        <PackageReference Include="Fuchu.FsCheck" Version="1.1.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Fleece.NewtonsoftJson\Fleece.NewtonsoftJson.fsproj" />
+    </ItemGroup>
 </Project>

--- a/test/Tests.SystemJson/Tests.SystemJson.fsproj
+++ b/test/Tests.SystemJson/Tests.SystemJson.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
         <DefineConstants>SYSTEMJSON;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/test/Tests.SystemJson/Tests.SystemJson.fsproj
+++ b/test/Tests.SystemJson/Tests.SystemJson.fsproj
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
-    <DefineConstants>SYSTEMJSON;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="../Tests/Lenses.fs" />
-    <Compile Include="../Tests/Tests.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FsCheck" Version="2.14.2" />
-    <PackageReference Include="Fuchu" Version="1.1.0" />
-    <PackageReference Include="Fuchu.FsCheck" Version="1.1.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Fleece.SystemJson\Fleece.SystemJson.fsproj" />
-  </ItemGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <DefineConstants>SYSTEMJSON;$(DefineConstants)</DefineConstants>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="../Tests/Lenses.fs" />
+        <Compile Include="../Tests/Tests.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="FsCheck" Version="2.14.2" />
+        <PackageReference Include="Fuchu" Version="1.1.0" />
+        <PackageReference Include="Fuchu.FsCheck" Version="1.1.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Fleece.SystemJson\Fleece.SystemJson.fsproj" />
+    </ItemGroup>
 </Project>

--- a/test/Tests.SystemTextJson/Tests.SystemTextJson.fsproj
+++ b/test/Tests.SystemTextJson/Tests.SystemTextJson.fsproj
@@ -1,21 +1,21 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
-    <DefineConstants>SYSTEMTEXTJSON;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="../Tests/Lenses.fs" />
-    <Compile Include="../Tests/Tests.fs" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="FsCheck" Version="2.14.2" />
-    <PackageReference Include="Fuchu" Version="1.1.0" />
-    <PackageReference Include="Fuchu.FsCheck" Version="1.1.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Fleece.SystemTextJson\Fleece.SystemTextJson.fsproj" />
-  </ItemGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+        <DefineConstants>SYSTEMTEXTJSON;$(DefineConstants)</DefineConstants>
+    </PropertyGroup>
+    <ItemGroup>
+        <Compile Include="../Tests/Lenses.fs" />
+        <Compile Include="../Tests/Tests.fs" />
+    </ItemGroup>
+    <ItemGroup>
+        <PackageReference Update="FSharp.Core" Version="4.6.2" />
+        <PackageReference Include="FsCheck" Version="2.14.2" />
+        <PackageReference Include="Fuchu" Version="1.1.0" />
+        <PackageReference Include="Fuchu.FsCheck" Version="1.1.0" />
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Fleece.SystemTextJson\Fleece.SystemTextJson.fsproj" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
This commit is one possible solution to #96. Here, I'm simply dropping support
for net461 entirely, in favor of targeting `netstandard`. While I was doing
this, I bumped the `netstandard` version to 2.1, but this could easily be an
addition instead of a replacement. Similarly, I noted that the `global.json`
specified SDK version 3.0, but with a roll-forward directive for newest minor
version. Accordingly, I bumped to the newest SDK 3.1 release. These changes
meant I could remove the `mono` block from the Fleece solution, so I did.

These changes reach all through Fleece, and prompted the replacement of `net461`
with `netstandard2.1` (mostly in documentation) or `netcoreapp3.1` (mostly in
tests) in many places. While I was doing this, I cleaned whitespace and
indentation, and added a missing XML specifier to an fsproj file.

On my machine, the build and all tests are passing.

Closes #96 