### PR TITLE
+ bigint

### DIFF
--- a/src/Fleece.FSharpData/Fleece.FSharpData.fs
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fs
@@ -23,6 +23,7 @@ module Internals =
         static member create (x: byte   ) : JsonValue = JsonValue.Number (decimal x)
         static member create (x: sbyte  ) : JsonValue = JsonValue.Number (decimal x)
         static member create (x: char   ) : JsonValue = JsonValue.String (string  x)
+        static member create (x: bigint ) : JsonValue = JsonValue.String (string  x)
         static member create (x: Guid   ) : JsonValue = JsonValue.String (string  x)
 
 
@@ -204,6 +205,12 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    -> Ok s.[0]
         | a -> Decode.Fail.strExpected (Encoding a)
 
+    static member bigintD x =
+        match x with
+        | JString null -> Decode.Fail.nullString
+        | JString s    -> match tryParse s with (Some (value: bigint)) -> Ok value | _ -> Decode.Fail.invalidValue (Encoding x) s
+        | a -> Decode.Fail.strExpected (Encoding a)
+
     static member guidD x =
         match x with
         | JString null -> Decode.Fail.nullString
@@ -289,6 +296,7 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     static member byteE           (x: byte          ) = JsonHelpers.create x
     static member sbyteE          (x: sbyte         ) = JsonHelpers.create x
     static member charE           (x: char          ) = JsonHelpers.create x
+    static member bigintE         (x: bigint        ) = JsonHelpers.create x
     static member guidE           (x: Guid          ) = JsonHelpers.create x
 
     
@@ -331,6 +339,7 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     static member byte           = Encoding.byteD           <-> Encoding.byteE
     static member sbyte          = Encoding.sbyteD          <-> Encoding.sbyteE
     static member char           = Encoding.charD           <-> Encoding.charE
+    static member bigint         = Encoding.bigintD         <-> Encoding.bigintE
     static member guid           = Encoding.guidD           <-> Encoding.guidE
 
 
@@ -353,6 +362,7 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         member _.byte           = Encoding.toIEncoding Encoding.byte
         member _.sbyte          = Encoding.toIEncoding Encoding.sbyte
         member _.char           = Encoding.toIEncoding Encoding.char
+        member _.bigint         = Encoding.toIEncoding Encoding.bigint
         member _.guid           = Encoding.toIEncoding Encoding.guid
 
         member _.result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fs
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fs
@@ -32,6 +32,7 @@ module Internals =
        static member create (x: byte   )  = JValue         x  :> JToken
        static member create (x: sbyte  )  = JValue         x  :> JToken
        static member create (x: char   )  = JValue (string x) :> JToken
+       static member create (x: bigint )  = JValue         x  :> JToken
        static member create (x: Guid   )  = JValue (string x) :> JToken
        static member create (x: DateTime) = JValue         x  :> JToken
 
@@ -220,6 +221,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    -> Ok s.[0]
         | a -> Decode.Fail.strExpected (Encoding a)
 
+    static member bigintD x = Encoding.tryRead<bigint>  x
+
     static member guidD x =
         match x with
         | JString null -> Decode.Fail.nullString
@@ -307,6 +310,7 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     static member byteE           (x: byte          ) = JsonHelpers.create x
     static member sbyteE          (x: sbyte         ) = JsonHelpers.create x
     static member charE           (x: char          ) = JsonHelpers.create x
+    static member bigintE         (x: bigint        ) = JsonHelpers.create x
     static member guidE           (x: Guid          ) = JsonHelpers.create x
 
     
@@ -349,6 +353,7 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     static member byte           = Encoding.byteD           <-> Encoding.byteE
     static member sbyte          = Encoding.sbyteD          <-> Encoding.sbyteE
     static member char           = Encoding.charD           <-> Encoding.charE
+    static member bigint         = Encoding.bigintD         <-> Encoding.bigintE
     static member guid           = Encoding.guidD           <-> Encoding.guidE
 
 
@@ -371,6 +376,7 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         member _.byte           = Encoding.toIEncoding Encoding.byte
         member _.sbyte          = Encoding.toIEncoding Encoding.sbyte
         member _.char           = Encoding.toIEncoding Encoding.char
+        member _.bigint         = Encoding.toIEncoding Encoding.bigint
         member _.guid           = Encoding.toIEncoding Encoding.guid
 
         member _.result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fs
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fs
@@ -28,6 +28,7 @@ module Internals =
        static member create (x: byte   ) = JsonPrimitive x :> JsonValue
        static member create (x: sbyte  ) = JsonPrimitive x :> JsonValue
        static member create (x: char   ) = JsonPrimitive (string x) :> JsonValue
+       static member create (x: bigint ) = JsonPrimitive (string x) :> JsonValue
        static member create (x: Guid   ) = JsonPrimitive (string x) :> JsonValue
 
 
@@ -205,6 +206,12 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    -> Ok s.[0]
         | a -> Decode.Fail.strExpected (Encoding a)
 
+    static member bigintD x =
+        match x with
+        | JString null -> Decode.Fail.nullString
+        | JString s    -> match tryParse s with (Some (value: bigint)) -> Ok value | _ -> Decode.Fail.invalidValue (Encoding x) s
+        | a -> Decode.Fail.strExpected (Encoding a)
+
     static member guidD x =
         match x with
         | JString null -> Decode.Fail.nullString
@@ -290,6 +297,7 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     static member byteE           (x: byte          ) = JsonHelpers.create x
     static member sbyteE          (x: sbyte         ) = JsonHelpers.create x
     static member charE           (x: char          ) = JsonHelpers.create x
+    static member bigintE         (x: bigint        ) = JsonHelpers.create x
     static member guidE           (x: Guid          ) = JsonHelpers.create x
 
     
@@ -332,6 +340,7 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     static member byte           = Encoding.byteD           <-> Encoding.byteE
     static member sbyte          = Encoding.sbyteD          <-> Encoding.sbyteE
     static member char           = Encoding.charD           <-> Encoding.charE
+    static member bigint         = Encoding.bigintD         <-> Encoding.bigintE
     static member guid           = Encoding.guidD           <-> Encoding.guidE
 
 
@@ -354,6 +363,7 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         member _.byte           = Encoding.toIEncoding Encoding.byte
         member _.sbyte          = Encoding.toIEncoding Encoding.sbyte
         member _.char           = Encoding.toIEncoding Encoding.char
+        member _.bigint         = Encoding.toIEncoding Encoding.bigint
         member _.guid           = Encoding.toIEncoding Encoding.guid
 
         member _.result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))

--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -129,6 +129,7 @@ and IEncoding =
     abstract byte           : Codec<IEncoding, byte>
     abstract sbyte          : Codec<IEncoding, sbyte>
     abstract char           : Codec<IEncoding, char>
+    abstract bigint         : Codec<IEncoding, bigint>
     abstract guid           : Codec<IEncoding, Guid>
     abstract result         : Codec<IEncoding, 't1> -> Codec<IEncoding, 't2> -> Codec<IEncoding, Result<'t1,'t2>>
     abstract choice         : Codec<IEncoding, 't1> -> Codec<IEncoding, 't2> -> Codec<IEncoding, Choice<'t1,'t2>>
@@ -232,6 +233,7 @@ type AdHocEncoding = AdHocEncoding of AdHocEncodingPassing: (IEncoding -> IEncod
         member _.byte           = AdHocEncoding.toIEncoding (fun x -> x.byte)
         member _.sbyte          = AdHocEncoding.toIEncoding (fun x -> x.sbyte)
         member _.char           = AdHocEncoding.toIEncoding (fun x -> x.char)
+        member _.bigint         = AdHocEncoding.toIEncoding (fun x -> x.bigint)
         member _.guid           = AdHocEncoding.toIEncoding (fun x -> x.guid)
         member _.enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<IEncoding, 't> = AdHocEncoding.toIEncoding (fun x -> x.enum ())
 
@@ -389,6 +391,7 @@ module Codecs =
 
     let [<GeneralizableValue>] unit<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>           = instance<'Encoding>.unit           |> Codec.downCast : Codec<'Encoding, _>
     let [<GeneralizableValue>] boolean<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>        = instance<'Encoding>.boolean        |> Codec.downCast : Codec<'Encoding, _>
+    let [<GeneralizableValue>] bigint<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>         = instance<'Encoding>.bigint         |> Codec.downCast : Codec<'Encoding, _>
     let [<GeneralizableValue>] guid<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>           = instance<'Encoding>.guid           |> Codec.downCast : Codec<'Encoding, _>
     let [<GeneralizableValue>] char<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>           = instance<'Encoding>.char           |> Codec.downCast : Codec<'Encoding, _>
     let [<GeneralizableValue>] byte<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>           = instance<'Encoding>.byte           |> Codec.downCast : Codec<'Encoding, _>
@@ -529,6 +532,7 @@ module Internals =
         static member GetCodec (_: byte          , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.byte
         static member GetCodec (_: sbyte         , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.sbyte
         static member GetCodec (_: char          , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.char
+        static member GetCodec (_: bigint        , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.bigint
         static member GetCodec (_: Guid          , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.guid
         static member GetCodec (()               , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.unit
 

--- a/test/Tests/Tests.fs
+++ b/test/Tests/Tests.fs
@@ -279,7 +279,27 @@ let tests = [
                 let expected = 
                     { Attribute.Name = "a name"
                       Value = null }
-                Assert.Equal("attribute", Some expected, Option.ofResult actual)           
+                Assert.Equal("attribute", Some expected, Option.ofResult actual)
+            }
+
+            test "Big Integer" {
+                let js =
+                #if FSHARPDATA
+                    """[[1,"10000000000000000000000000000005767000000000000000000001"]]"""
+                #endif
+                #if SYSTEMJSON
+                    """[[1,"10000000000000000000000000000005767000000000000000000001"]]"""
+                #endif
+                #if SYSTEMTEXTJSON
+                    """[[1,10000000000000000000000000000005767000000000000000000001]]"""
+                #endif
+                #if NEWTONSOFT
+                    """[[1,10000000000000000000000000000005767000000000000000000001]]"""
+                #endif
+                
+                let actual: ParseResult<list<int * bigint>> = ofJsonText js
+                let expected = [(1, 10000000000000000000000000000005767000000000000000000001I)]
+                Assert.Equal("bigint", Some expected, Option.ofResult actual)
             }
 
             test "Person recursive" {

--- a/test/Tests/Tests.fs
+++ b/test/Tests/Tests.fs
@@ -649,6 +649,7 @@ let tests = [
             yield testProperty "char" (roundtrip<char>)
             yield testProperty "byte" (roundtrip<byte>)
             yield testProperty "sbyte" (roundtrip<sbyte>)
+            yield testProperty "bigint" (roundtrip<bigint>)
             yield testProperty "Guid" (roundtrip<Guid>)
             yield testProperty "attribute" (Prop.forAll attributeArb.Value roundtrip<Attribute>)
             yield testProperty "string list" (roundtrip<string list>)


### PR DESCRIPTION
Add overload for bigint.

The problem is that FSharp.Data and System.Json can't read properly a json with a big integer as a numeric value as it would be truncated. So for those libs `bigint` will be stored/retrieved as a JsonString instead as a JsonNumber.