### PR TITLE
Make `jopt`  generic to all types supporting Zero

### DIFF
--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -890,8 +890,18 @@ module Operators =
             match m.[key] with
             | []        -> Ok z
             | value:: _ -> decoder value
-        (fun (o: PropertyList<'S>) -> getFromListOptWith (Codec.decode c) o prop)
+        (fun (o: PropertyList<'Encoding>) -> getFromListOptWith (Codec.decode c) o prop)
         <-> (fun x -> match getter x with (x: 'Value) when x <> z -> PropertyList [| prop, Codec.encode c x |] | _ -> zero)
+
+    /// <summary>Same as joptWith but using a thunk for the explicit codec. Useful for recursive types.</summary>
+    let inline joptWithLazy (c: unit -> Codec<'Encoding,_,_,'Value>) (prop: string) (getter: 'T -> 'Value) =
+        let z = zero<'Value>
+        let getFromListOptWith decoder (m: PropertyList<_>) key =
+            match m.[key] with
+            | []        -> Ok z
+            | value:: _ -> decoder value
+        (fun (o: PropertyList<'Encoding>) -> getFromListOptWith (Codec.decode (c ())) o prop)
+        <-> (fun x -> match getter x with (x: 'Value) when x <> z -> PropertyList [| prop, Codec.encode (c ()) x |] | _ -> zero)
 
     [<Obsolete("Use codec computation expression instead.")>]
     let inline jchoice (codecs: seq<Codec<PropertyList<'Encoding>, PropertyList<'Encoding>, 't1, 't2>>) =
@@ -899,7 +909,7 @@ module Operators =
         foldBack (<|>) tail head
     
     /// Derives a concrete field codec for an optional field.
-    let inline jopt prop (getter: 'T -> 'param) : Codec<PropertyList<'Encoding>, PropertyList<'Encoding>, 'param, 'T> = joptWith defaultCodec<'Encoding, 'param> prop getter
+    let inline jopt prop (getter: 'T -> 'param) : Codec<PropertyList<'Encoding>, PropertyList<'Encoding>, 'param, 'T> = joptWithLazy (fun () -> defaultCodec<'Encoding, 'param>) prop getter
 
 
     let jobj (x: list<string * 'Encoding>) : 'Encoding = x |> List.toArray |> PropertyList |> Codec.encode (Codecs.propList Codecs.id)

--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -884,13 +884,14 @@ module Operators =
     let inline jreq (name: string) (getter: 'T -> 'param option) : Codec<PropertyList<'Encoding>, PropertyList<'Encoding>, 'param, 'T> = jreqWithLazy (fun () -> defaultCodec<'Encoding, 'param>) name getter
 
     /// <summary>Same as jopt but using an explicit codec.</summary>
-    let joptWith c (prop: string) (getter: 'T -> 'Value option) =
+    let inline joptWith c (prop: string) (getter: 'T -> 'Value) =
+        let z = zero<'Value>
         let getFromListOptWith decoder (m: PropertyList<_>) key =
             match m.[key] with
-            | []        -> Ok None
-            | value:: _ -> decoder value |> Result.map Some
+            | []        -> Ok z
+            | value:: _ -> decoder value
         (fun (o: PropertyList<'S>) -> getFromListOptWith (Codec.decode c) o prop)
-        <-> (fun x -> match getter x with Some (x: 'Value) -> PropertyList [| prop, Codec.encode c x |] | _ -> zero)
+        <-> (fun x -> match getter x with (x: 'Value) when x <> z -> PropertyList [| prop, Codec.encode c x |] | _ -> zero)
 
     [<Obsolete("Use codec computation expression instead.")>]
     let inline jchoice (codecs: seq<Codec<PropertyList<'Encoding>, PropertyList<'Encoding>, 't1, 't2>>) =
@@ -898,7 +899,7 @@ module Operators =
         foldBack (<|>) tail head
     
     /// Derives a concrete field codec for an optional field.
-    let inline jopt prop (getter: 'T -> 'param option) : Codec<PropertyList<'Encoding>, PropertyList<'Encoding>, 'param option, 'T> = joptWith defaultCodec<'Encoding, 'param> prop getter
+    let inline jopt prop (getter: 'T -> 'param) : Codec<PropertyList<'Encoding>, PropertyList<'Encoding>, 'param, 'T> = joptWith defaultCodec<'Encoding, 'param> prop getter
 
 
     let jobj (x: list<string * 'Encoding>) : 'Encoding = x |> List.toArray |> PropertyList |> Codec.encode (Codecs.propList Codecs.id)

--- a/test/IntegrationCompilationTests/Library.fs
+++ b/test/IntegrationCompilationTests/Library.fs
@@ -180,7 +180,7 @@ module TestSingleCodecForAllJsonLibrary =
                 and! age      = jreq "Age"      (fun x -> Some x.Age)
                 and! gender   = jreq "Gender"   (fun x -> Some x.Gender)
                 and! dob      = jreq "DoB"      (fun x -> Some x.DoB)
-                and! children = jreq "Children" (fun x -> Some x.Children)
+                and! children = jopt "Children" (fun x ->      x.Children)
                 return { Name = name; Age = age; Gender = gender; DoB= dob; Children = children }
             } |> ofObjCodec
 

--- a/test/IntegrationCompilationTests/Library.fs
+++ b/test/IntegrationCompilationTests/Library.fs
@@ -159,6 +159,7 @@ module TestSingleDecoderEncoderForAllJsonLibrary =
 module TestSingleCodecForAllJsonLibrary =
 
     open System
+    open FSharpPlus
     open Fleece
 
     type Gender =
@@ -209,6 +210,7 @@ module TestSingleCodecForAllJsonLibrary =
 
     Assert.StringContains ("", "DoB", personText1)
     Assert.StringContains ("", "DoB", personText2)
+    Assert.None ("", String.tryFindSliceIndex """Children":[]""" personText2)
 
 
 module TestDifferentDecoderEncoderForEachJsonLibrary =


### PR DESCRIPTION
Until now `jopt` related combinators worked only with options.

With this PR we can make it work with `voption`, `Nullable`, lists and in general with any type which support the `Zero` operation.

While testing this I realized `jopt` has the same problem with recursion as `jreq` so it needs to call a lazy version.
This wasn't evident as we didn't have a test with a recursive option value and the `jopt` combinator.
