### PR TITLE
Add DateOnly and TimeOnly

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,9 +15,13 @@ build_script:
   - cmd: build.bat
 test_script:
   - cmd: dotnet run --project .\test\Tests.SystemJson\Tests.SystemJson.fsproj -c Release -f net461
+  - cmd: dotnet run --project .\test\Tests.SystemJson\Tests.SystemJson.fsproj -c Release -f net6
   - cmd: dotnet run --project .\test\Tests.FSharpData\Tests.FSharpData.fsproj -c Release -f net6
+  - cmd: dotnet run --project .\test\Tests.FSharpData\Tests.FSharpData.fsproj -c Release -f netcoreapp31
   - cmd: dotnet run --project .\test\Tests.NewtonsoftJson\Tests.NewtonsoftJson.fsproj -c Release -f net6
+  - cmd: dotnet run --project .\test\Tests.NewtonsoftJson\Tests.NewtonsoftJson.fsproj -c Release -f netcoreapp31
   - cmd: dotnet run --project .\test\Tests.SystemTextJson\Tests.SystemTextJson.fsproj -c Release -f net6
+  - cmd: dotnet run --project .\test\Tests.SystemTextJson\Tests.SystemTextJson.fsproj -c Release -f netcoreapp31
   - cmd: dotnet run --project .\test\IntegrationCompilationTests\IntegrationCompilationTests.fsproj -c Release -f net6
 
 artifacts:

--- a/src/Fleece.FSharpData/Fleece.FSharpData.fs
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fs
@@ -195,8 +195,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    ->
             match DateTime.TryParseExact (s, [|"yyyy-MM-dd" |], null, DateTimeStyles.RoundtripKind) with
             | true, t -> Ok t
-            | _       -> Decode.Fail.invalidValue x ""
-        | a -> Decode.Fail.strExpected a
+            | _       -> Decode.Fail.invalidValue (Encoding x) ""
+        | a -> Decode.Fail.strExpected (Encoding a)
 
     static member timeD x =
         match x with
@@ -204,8 +204,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    ->
             match DateTime.TryParseExact (s, [| "HH:mm:ss.fff"; "HH:mm:ss" |], null, DateTimeStyles.RoundtripKind) with
             | true, t -> Ok t
-            | _       -> Decode.Fail.invalidValue x ""
-        | a -> Decode.Fail.strExpected a
+            | _       -> Decode.Fail.invalidValue (Encoding x) ""
+        | a -> Decode.Fail.strExpected (Encoding a)
 
     static member dateTimeD x =
         match x with
@@ -270,8 +270,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
 
     static member booleanE        (x: bool          ) = JBool x
     static member stringE         (x: string        ) = JString x
-    static member dateE           (x: DateTime      ) = Encoding.JString (x.ToString "yyyy-MM-dd")
-    static member timeE           (x: DateTime      ) = Encoding.JString (x.ToString "HH:mm:ss.fff")
+    static member dateE           (x: DateTime      ) = JString (x.ToString "yyyy-MM-dd")
+    static member timeE           (x: DateTime      ) = JString (x.ToString "HH:mm:ss.fff")
     static member dateTimeE       (x: DateTime      ) = JString (x.ToString ("yyyy-MM-ddTHH:mm:ss.fffZ"))
     static member dateTimeOffsetE (x: DateTimeOffset) = JString (x.ToString ("yyyy-MM-ddTHH:mm:ss.fffK"))
     static member timeSpanE       (x: TimeSpan      ) = JsonHelpers.create x.Ticks

--- a/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for FSharp.Data</Description>
     <DefineConstants>FSHARPDATA;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for FSharp.Data</Description>
     <DefineConstants>FSHARPDATA;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fs
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fs
@@ -208,9 +208,9 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    ->
             match DateTime.TryParseExact (s, [|"yyyy-MM-dd" |], null, DateTimeStyles.RoundtripKind) with
             | true, t -> Ok t
-            | _       -> Decode.Fail.invalidValue x ""
+            | _       -> Decode.Fail.invalidValue (Encoding x) ""
         | JDate d -> Ok (d.Value<DateTime> ())
-        | a -> Decode.Fail.strExpected a
+        | a -> Decode.Fail.strExpected (Encoding a)
 
     static member timeD x =
         match x with
@@ -219,9 +219,9 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    ->
             match DateTime.TryParseExact (s, [| "HH:mm:ss.fff"; "HH:mm:ss" |], null, DateTimeStyles.RoundtripKind) with
             | true, t -> Ok t
-            | _       -> Decode.Fail.invalidValue x ""
+            | _       -> Decode.Fail.invalidValue (Encoding x) ""
         | JDate d -> Ok (d.Value<DateTime> ())
-        | a -> Decode.Fail.strExpected a
+        | a -> Decode.Fail.strExpected (Encoding a)
 
     static member dateTimeD x =
         match x with
@@ -288,8 +288,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
 
     static member booleanE        (x: bool          ) = JBool x
     static member stringE         (x: string        ) = JString x
-    static member dateE           (x: DateTime      ) = Encoding.JString (x.ToString "yyyy-MM-dd")
-    static member timeE           (x: DateTime      ) = Encoding.JString (x.ToString "HH:mm:ss.fff")
+    static member dateE           (x: DateTime      ) = JString (x.ToString "yyyy-MM-dd")
+    static member timeE           (x: DateTime      ) = JString (x.ToString "HH:mm:ss.fff")
     static member dateTimeE       (x: DateTime      ) = JString (x.ToString ("yyyy-MM-ddTHH:mm:ss.fffZ"))
     static member dateTimeOffsetE (x: DateTimeOffset) = JString (x.ToString ("yyyy-MM-ddTHH:mm:ss.fffK"))
     static member timeSpanE       (x: TimeSpan) = JsonHelpers.create x.Ticks

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fs
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fs
@@ -201,6 +201,28 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    -> match Guid.TryParse s with (true, value) -> Ok value | _ -> Decode.Fail.invalidValue (Encoding x) s
         | a -> Decode.Fail.strExpected (Encoding a)
 
+    static member dateD x =
+        match x with
+        | JString null
+        | JDate null -> Decode.Fail.nullString
+        | JString s    ->
+            match DateTime.TryParseExact (s, [|"yyyy-MM-dd" |], null, DateTimeStyles.RoundtripKind) with
+            | true, t -> Ok t
+            | _       -> Decode.Fail.invalidValue x ""
+        | JDate d -> Ok (d.Value<DateTime> ())
+        | a -> Decode.Fail.strExpected a
+
+    static member timeD x =
+        match x with
+        | JString null
+        | JDate null -> Decode.Fail.nullString
+        | JString s    ->
+            match DateTime.TryParseExact (s, [| "HH:mm:ss.fff"; "HH:mm:ss" |], null, DateTimeStyles.RoundtripKind) with
+            | true, t -> Ok t
+            | _       -> Decode.Fail.invalidValue x ""
+        | JDate d -> Ok (d.Value<DateTime> ())
+        | a -> Decode.Fail.strExpected a
+
     static member dateTimeD x =
         match x with
         | JString null
@@ -266,6 +288,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
 
     static member booleanE        (x: bool          ) = JBool x
     static member stringE         (x: string        ) = JString x
+    static member dateE           (x: DateTime      ) = Encoding.JString (x.ToString "yyyy-MM-dd")
+    static member timeE           (x: DateTime      ) = Encoding.JString (x.ToString "HH:mm:ss.fff")
     static member dateTimeE       (x: DateTime      ) = JString (x.ToString ("yyyy-MM-ddTHH:mm:ss.fffZ"))
     static member dateTimeOffsetE (x: DateTimeOffset) = JString (x.ToString ("yyyy-MM-ddTHH:mm:ss.fffK"))
     static member timeSpanE       (x: TimeSpan) = JsonHelpers.create x.Ticks
@@ -301,6 +325,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
 
     static member boolean        =  Encoding.booleanD       <-> Encoding.booleanE
     static member string         = Encoding.stringD         <-> Encoding.stringE
+    static member date           = Encoding.dateD           <-> Encoding.dateE
+    static member time           = Encoding.timeD           <-> Encoding.timeE
     static member dateTime       = Encoding.dateTimeD       <-> Encoding.dateTimeE
     static member dateTimeOffset = Encoding.dateTimeOffsetD <-> Encoding.dateTimeOffsetE
     static member timeSpan       = Encoding.timeSpanD       <-> Encoding.timeSpanE
@@ -323,7 +349,11 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     interface IEncoding with
         member _.boolean        = Encoding.toIEncoding Encoding.boolean
         member _.string         = Encoding.toIEncoding Encoding.string
-        member _.dateTime       = Encoding.toIEncoding Encoding.dateTime
+        member _.dateTime t     =
+            match t with            
+            | Some DateTimeContents.Date -> Encoding.toIEncoding Encoding.date
+            | Some DateTimeContents.Time -> Encoding.toIEncoding Encoding.time
+            | _                          -> Encoding.toIEncoding Encoding.dateTime
         member _.dateTimeOffset = Encoding.toIEncoding Encoding.dateTimeOffset
         member _.timeSpan       = Encoding.toIEncoding Encoding.timeSpan
         member _.decimal        = Encoding.toIEncoding Encoding.decimal

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for Newtonsoft Json</Description>
     <DefineConstants>NEWTONSOFT;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for Newtonsoft Json</Description>
     <DefineConstants>NEWTONSOFT;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fs
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fs
@@ -190,6 +190,24 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    -> match Guid.TryParse s with (true, value) -> Ok value | _ -> Decode.Fail.invalidValue (Encoding x) s
         | a -> Decode.Fail.strExpected (Encoding a)
 
+    static member dateD x =
+        match x with
+        | JString null -> Decode.Fail.nullString
+        | JString s    ->
+            match DateTime.TryParseExact (s, [|"yyyy-MM-dd" |], null, DateTimeStyles.RoundtripKind) with
+            | true, t -> Ok t
+            | _       -> Decode.Fail.invalidValue x ""
+        | a -> Decode.Fail.strExpected a
+
+    static member timeD x =
+        match x with
+        | JString null -> Decode.Fail.nullString
+        | JString s    ->
+            match DateTime.TryParseExact (s, [| "HH:mm:ss.fff"; "HH:mm:ss" |], null, DateTimeStyles.RoundtripKind) with
+            | true, t -> Ok t
+            | _       -> Decode.Fail.invalidValue x ""
+        | a -> Decode.Fail.strExpected a
+
     static member dateTimeD x =
         match x with
         | JString null -> Decode.Fail.nullString
@@ -253,6 +271,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
 
     static member booleanE        (x: bool          ) = JBool x
     static member stringE         (x: string        ) = JString x
+    static member dateE           (x: DateTime      ) = JString (x.ToString "yyyy-MM-dd")
+    static member timeE           (x: DateTime      ) = JString (x.ToString "HH:mm:ss.fff")
     static member dateTimeE       (x: DateTime      ) = JString (x.ToString ("yyyy-MM-ddTHH:mm:ss.fffZ"))
     static member dateTimeOffsetE (x: DateTimeOffset) = JString (x.ToString ("yyyy-MM-ddTHH:mm:ss.fffK"))
     static member timeSpanE       (x: TimeSpan) = JsonHelpers.create x.Ticks
@@ -288,6 +308,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
 
     static member boolean        = Encoding.booleanD        <-> Encoding.booleanE
     static member string         = Encoding.stringD         <-> Encoding.stringE
+    static member date           = Encoding.dateD           <-> Encoding.dateE
+    static member time           = Encoding.timeD           <-> Encoding.timeE
     static member dateTime       = Encoding.dateTimeD       <-> Encoding.dateTimeE
     static member dateTimeOffset = Encoding.dateTimeOffsetD <-> Encoding.dateTimeOffsetE
     static member timeSpan       = Encoding.timeSpanD       <-> Encoding.timeSpanE
@@ -310,7 +332,11 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     interface IEncoding with
         member _.boolean        = Encoding.toIEncoding Encoding.boolean
         member _.string         = Encoding.toIEncoding Encoding.string
-        member _.dateTime       = Encoding.toIEncoding Encoding.dateTime
+        member _.dateTime t     =
+            match t with            
+            | Some DateTimeContents.Date -> Encoding.toIEncoding Encoding.date
+            | Some DateTimeContents.Time -> Encoding.toIEncoding Encoding.time
+            | _                          -> Encoding.toIEncoding Encoding.dateTime
         member _.dateTimeOffset = Encoding.toIEncoding Encoding.dateTimeOffset
         member _.timeSpan       = Encoding.toIEncoding Encoding.timeSpan
         member _.decimal        = Encoding.toIEncoding Encoding.decimal

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fs
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fs
@@ -196,8 +196,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    ->
             match DateTime.TryParseExact (s, [|"yyyy-MM-dd" |], null, DateTimeStyles.RoundtripKind) with
             | true, t -> Ok t
-            | _       -> Decode.Fail.invalidValue x ""
-        | a -> Decode.Fail.strExpected a
+            | _       -> Decode.Fail.invalidValue (Encoding x) ""
+        | a -> Decode.Fail.strExpected (Encoding a)
 
     static member timeD x =
         match x with
@@ -205,8 +205,8 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | JString s    ->
             match DateTime.TryParseExact (s, [| "HH:mm:ss.fff"; "HH:mm:ss" |], null, DateTimeStyles.RoundtripKind) with
             | true, t -> Ok t
-            | _       -> Decode.Fail.invalidValue x ""
-        | a -> Decode.Fail.strExpected a
+            | _       -> Decode.Fail.invalidValue (Encoding x) ""
+        | a -> Decode.Fail.strExpected (Encoding a)
 
     static member dateTimeD x =
         match x with

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for System.Json</Description>
     <DefineConstants>SYSTEMJSON;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for System.Json</Description>
     <DefineConstants>SYSTEMJSON;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
+++ b/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for System.Text.Json</Description>
     <DefineConstants>SYSTEMTEXTJSON;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
+++ b/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for System.Text.Json</Description>
     <DefineConstants>SYSTEMTEXTJSON;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
+++ b/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for System.Text.Json</Description>
     <DefineConstants>SYSTEMTEXTJSON;$(DefineConstants)</DefineConstants>

--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -576,8 +576,10 @@ module Internals =
 
         static member GetCodec (_: bool          , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.boolean
         static member GetCodec (_: string        , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.string
+#if NET6
         static member GetCodec (_: DateOnly      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTime
         static member GetCodec (_: TimeOnly      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTime
+#endif
         static member GetCodec (_: DateTime      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTime
         static member GetCodec (_: DateTimeOffset, _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTimeOffset
         static member GetCodec (_: TimeSpan      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.timeSpan

--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -415,10 +415,10 @@ module Codecs =
     let choice  (codec1: Codec<'Encoding, 'a>)  (codec2: Codec<'Encoding, 'b>) = instance<'Encoding>.choice (Codec.upCast codec1) (Codec.upCast codec2) |> Codec.downCast : Codec<'Encoding, Choice<'a,'b>>
     let choice3 (codec1: Codec<'Encoding, 't1>) (codec2: Codec<'Encoding, 't2>) (codec3: Codec<'Encoding, 't3>) = instance<'Encoding>.choice3 (Codec.upCast codec1) (Codec.upCast codec2) (Codec.upCast codec3) |> Codec.downCast : Codec<'Encoding, _>
     
-    // if net6
+#if NET6
     let [<GeneralizableValue>] date<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = instance<'Encoding>.dateTime DateTimeContents.Date |> Codec.downCast : Codec<'Encoding, _>
     let [<GeneralizableValue>] time<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = instance<'Encoding>.dateTime DateTimeContents.Time |> Codec.downCast : Codec<'Encoding, _>
-    //
+#endif
 
     let [<GeneralizableValue>]id<'T> : Codec<'T, 'T> = Ok <-> id
 
@@ -577,8 +577,8 @@ module Internals =
         static member GetCodec (_: bool          , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.boolean
         static member GetCodec (_: string        , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.string
 #if NET6
-        static member GetCodec (_: DateOnly      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTime
-        static member GetCodec (_: TimeOnly      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTime
+        static member GetCodec (_: DateOnly      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.date
+        static member GetCodec (_: TimeOnly      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.time
 #endif
         static member GetCodec (_: DateTime      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTime
         static member GetCodec (_: DateTimeOffset, _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTimeOffset

--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -415,10 +415,10 @@ module Codecs =
     let choice  (codec1: Codec<'Encoding, 'a>)  (codec2: Codec<'Encoding, 'b>) = instance<'Encoding>.choice (Codec.upCast codec1) (Codec.upCast codec2) |> Codec.downCast : Codec<'Encoding, Choice<'a,'b>>
     let choice3 (codec1: Codec<'Encoding, 't1>) (codec2: Codec<'Encoding, 't2>) (codec3: Codec<'Encoding, 't3>) = instance<'Encoding>.choice3 (Codec.upCast codec1) (Codec.upCast codec2) (Codec.upCast codec3) |> Codec.downCast : Codec<'Encoding, _>
     
-#if NET6
-    let [<GeneralizableValue>] date<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = instance<'Encoding>.dateTime DateTimeContents.Date |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] time<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = instance<'Encoding>.dateTime DateTimeContents.Time |> Codec.downCast : Codec<'Encoding, _>
-#endif
+    #if NET6_0_OR_GREATER
+    let [<GeneralizableValue>] date<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = (Ok << DateOnly.FromDateTime <-> fun x -> x.ToDateTime (TimeOnly(0,0), DateTimeKind.Utc)) >.> instance<'Encoding>.dateTime DateTimeContents.Date |> Codec.downCast : Codec<'Encoding, _>
+    let [<GeneralizableValue>] time<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = (Ok << TimeOnly.FromDateTime <-> fun x -> DateTime x.Ticks)                               >.> instance<'Encoding>.dateTime DateTimeContents.Time |> Codec.downCast : Codec<'Encoding, _>
+    #endif
 
     let [<GeneralizableValue>]id<'T> : Codec<'T, 'T> = Ok <-> id
 
@@ -576,10 +576,10 @@ module Internals =
 
         static member GetCodec (_: bool          , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.boolean
         static member GetCodec (_: string        , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.string
-#if NET6
+        #if NET6_0_OR_GREATER
         static member GetCodec (_: DateOnly      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.date
         static member GetCodec (_: TimeOnly      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.time
-#endif
+        #endif
         static member GetCodec (_: DateTime      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTime
         static member GetCodec (_: DateTimeOffset, _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.dateTimeOffset
         static member GetCodec (_: TimeSpan      , _: GetCodec, _, _: 'Operation) : Codec<'Encoding, _> = Codecs.timeSpan

--- a/src/Fleece/Fleece.fsproj
+++ b/src/Fleece/Fleece.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <Description>Serialization library</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/src/Fleece/Fleece.fsproj
+++ b/src/Fleece/Fleece.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <Description>Serialization library</Description>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>

--- a/test/IntegrationCompilationTests/Library.fs
+++ b/test/IntegrationCompilationTests/Library.fs
@@ -659,3 +659,16 @@ module TestGenerics =
     let x: Fleece.SystemTextJson.Encoding = (listOfSomething () |> Codec.encode) [1]
     let y: Fleece.SystemTextJson.Encoding = (listOfSomething () |> Codec.encode) ['a']
     ()
+
+
+#if NET6_0_OR_GREATER
+module TestDateTime =
+    open System
+    open Fleece
+    open Fleece.SystemTextJson
+
+    let x = DateOnly (2022,5,22)
+    let json = toJsonText x
+    Assert.Equal ("DateOnly", "\"2022-05-22\"", json)
+#endif
+    

--- a/test/Tests.FSharpData/Tests.FSharpData.fsproj
+++ b/test/Tests.FSharpData/Tests.FSharpData.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6</TargetFrameworks>
+        <TargetFrameworks>netcoreapp31;net6</TargetFrameworks>
         <DefineConstants>FSHARPDATA;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>

--- a/test/Tests.NewtonsoftJson/Tests.NewtonsoftJson.fsproj
+++ b/test/Tests.NewtonsoftJson/Tests.NewtonsoftJson.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6</TargetFrameworks>
+        <TargetFrameworks>netcoreapp31;net6</TargetFrameworks>
         <DefineConstants>NEWTONSOFT;$(DefineConstants)</DefineConstants>
         <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     </PropertyGroup>

--- a/test/Tests.SystemTextJson/Tests.SystemTextJson.fsproj
+++ b/test/Tests.SystemTextJson/Tests.SystemTextJson.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net6</TargetFrameworks>
+        <TargetFrameworks>netcoreapp31;net6</TargetFrameworks>
         <DefineConstants>SYSTEMTEXTJSON;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
This will add support for Net6 `DateOnly` and `TimeOnly` types.

Fleece core can multitarget, but the idea is not to mess a lot with interface multitargeting, so this proposal uses `DateTime` as a interface vehicle to transport both Date and Time separately.

