### PR TITLE
Use static interfaces, remove AdHoc Encoding.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "6.0.0",
+        "version": "7.0.0",
         "rollForward": "latestMinor"
     }
 }

--- a/src/Fleece.FSharpData/Fleece.FSharpData.fs
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fs
@@ -82,13 +82,13 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | js                 -> Decode.Fail.numExpected (Encoding js)
 
     /// Unwraps the JsonValue inside an IEncoding
-    static member Unwrap (x: IEncoding) = x :?> Encoding |> fun (Encoding s) -> s
+    static member Unwrap (Encoding s) = s
 
     /// Wraps a JsonValue inside an IEncoding
-    static member Wrap x = Encoding x :> IEncoding
+    static member Wrap x = Encoding x
 
-    static member toIEncoding (c: Codec<JsonValue, 't>) : Codec<IEncoding, 't> = c |> Codec.compose ((Encoding.Unwrap >> Ok) <-> Encoding.Wrap)
-    static member ofIEncoding (c: Codec<IEncoding, 't>) : Codec<JsonValue, 't> = c |> Codec.compose ((Encoding.Wrap >> Ok) <-> Encoding.Unwrap)
+    static member toIEncoding (c: Codec<JsonValue, 't>) : Codec<Encoding, 't> = c |> Codec.compose ((Encoding.Unwrap >> Ok) <-> Encoding.Wrap)
+    static member ofIEncoding (c: Codec<Encoding, 't>) : Codec<JsonValue, 't> = c |> Codec.compose ((Encoding.Wrap >> Ok) <-> Encoding.Unwrap)
 
     static member jsonObjectOfJson = function
         | JObject x -> Ok (dictAsJsonObject x)
@@ -328,39 +328,39 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     static member guid           = Encoding.guidD           <-> Encoding.guidE
 
 
-    interface IEncoding with
-        member _.boolean        = Encoding.toIEncoding Encoding.boolean
-        member _.string         = Encoding.toIEncoding Encoding.string
-        member _.dateTime t     =
+    interface IEncoding<Encoding> with
+        static member boolean        = Encoding.toIEncoding Encoding.boolean
+        static member string         = Encoding.toIEncoding Encoding.string
+        static member dateTime t     =
             match t with            
             | Some DateTimeContents.Date -> Encoding.toIEncoding Encoding.date
             | Some DateTimeContents.Time -> Encoding.toIEncoding Encoding.time
             | _                          -> Encoding.toIEncoding Encoding.dateTime
-        member _.dateTimeOffset = Encoding.toIEncoding Encoding.dateTimeOffset
-        member _.timeSpan       = Encoding.toIEncoding Encoding.timeSpan
-        member _.decimal        = Encoding.toIEncoding Encoding.decimal
-        member _.float          = Encoding.toIEncoding Encoding.float
-        member _.float32        = Encoding.toIEncoding Encoding.float32
-        member _.int            = Encoding.toIEncoding Encoding.int
-        member _.uint32         = Encoding.toIEncoding Encoding.uint32
-        member _.int64          = Encoding.toIEncoding Encoding.int64
-        member _.uint64         = Encoding.toIEncoding Encoding.uint64
-        member _.int16          = Encoding.toIEncoding Encoding.int16
-        member _.uint16         = Encoding.toIEncoding Encoding.uint16
-        member _.byte           = Encoding.toIEncoding Encoding.byte
-        member _.sbyte          = Encoding.toIEncoding Encoding.sbyte
-        member _.char           = Encoding.toIEncoding Encoding.char
-        member _.bigint         = Encoding.toIEncoding Encoding.bigint
-        member _.guid           = Encoding.toIEncoding Encoding.guid
+        static member dateTimeOffset = Encoding.toIEncoding Encoding.dateTimeOffset
+        static member timeSpan       = Encoding.toIEncoding Encoding.timeSpan
+        static member decimal        = Encoding.toIEncoding Encoding.decimal
+        static member float          = Encoding.toIEncoding Encoding.float
+        static member float32        = Encoding.toIEncoding Encoding.float32
+        static member int            = Encoding.toIEncoding Encoding.int
+        static member uint32         = Encoding.toIEncoding Encoding.uint32
+        static member int64          = Encoding.toIEncoding Encoding.int64
+        static member uint64         = Encoding.toIEncoding Encoding.uint64
+        static member int16          = Encoding.toIEncoding Encoding.int16
+        static member uint16         = Encoding.toIEncoding Encoding.uint16
+        static member byte           = Encoding.toIEncoding Encoding.byte
+        static member sbyte          = Encoding.toIEncoding Encoding.sbyte
+        static member char           = Encoding.toIEncoding Encoding.char
+        static member bigint         = Encoding.toIEncoding Encoding.bigint
+        static member guid           = Encoding.toIEncoding Encoding.guid
 
-        member _.result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
-        member _.choice c1 c2     = Encoding.toIEncoding (Encoding.choice   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
-        member _.choice3 c1 c2 c3 = Encoding.toIEncoding (Encoding.choice3  (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2) (Encoding.ofIEncoding c3))
-        member _.option c         = Encoding.toIEncoding (Encoding.option   (Encoding.ofIEncoding c))
-        member _.array c          = Encoding.toIEncoding (Encoding.array    (Encoding.ofIEncoding c))
-        member _.propertyList c   = Encoding.toIEncoding (Encoding.multiMap (Encoding.ofIEncoding c))
+        static member result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
+        static member choice c1 c2     = Encoding.toIEncoding (Encoding.choice   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
+        static member choice3 c1 c2 c3 = Encoding.toIEncoding (Encoding.choice3  (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2) (Encoding.ofIEncoding c3))
+        static member option c         = Encoding.toIEncoding (Encoding.option   (Encoding.ofIEncoding c))
+        static member array c          = Encoding.toIEncoding (Encoding.array    (Encoding.ofIEncoding c))
+        static member propertyList c   = Encoding.toIEncoding (Encoding.multiMap (Encoding.ofIEncoding c))
 
-        member _.enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<IEncoding, 't> = Encoding.toIEncoding (Encoding.enumD <-> Encoding.enumE)
+        static member enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<Encoding, 't> = Encoding.toIEncoding (Encoding.enumD <-> Encoding.enumE)
 
         member x.getCase =
             match x with

--- a/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
+++ b/src/Fleece.FSharpData/Fleece.FSharpData.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for FSharp.Data</Description>
     <DefineConstants>FSHARPDATA;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fs
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fs
@@ -96,13 +96,13 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | js -> Decode.Fail.numExpected (Encoding js)
 
     /// Unwraps the JsonValue inside an IEncoding
-    static member Unwrap (x: IEncoding) = x :?> Encoding |> fun (Encoding s) -> s
+    static member Unwrap (Encoding s) = s
 
     /// Wraps a JsonValue inside an IEncoding
-    static member Wrap x = Encoding x :> IEncoding
+    static member Wrap x = Encoding x
 
-    static member toIEncoding (c: Codec<JsonValue, 't>) : Codec<IEncoding, 't> = c |> Codec.compose ((Encoding.Unwrap >> Ok) <-> Encoding.Wrap)
-    static member ofIEncoding (c: Codec<IEncoding, 't>) : Codec<JsonValue, 't> = c |> Codec.compose ((Encoding.Wrap >> Ok) <-> Encoding.Unwrap)
+    static member toIEncoding (c: Codec<JsonValue, 't>) : Codec<Encoding, 't> = c |> Codec.compose ((Encoding.Unwrap >> Ok) <-> Encoding.Wrap)
+    static member ofIEncoding (c: Codec<Encoding, 't>) : Codec<JsonValue, 't> = c |> Codec.compose ((Encoding.Wrap >> Ok) <-> Encoding.Unwrap)
 
     static member jsonObjectOfJson = 
         fun (o: JToken) ->
@@ -346,39 +346,39 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     static member guid           = Encoding.guidD           <-> Encoding.guidE
 
 
-    interface IEncoding with
-        member _.boolean        = Encoding.toIEncoding Encoding.boolean
-        member _.string         = Encoding.toIEncoding Encoding.string
-        member _.dateTime t     =
+    interface IEncoding<Encoding> with
+        static member boolean        = Encoding.toIEncoding Encoding.boolean
+        static member string         = Encoding.toIEncoding Encoding.string
+        static member dateTime t     =
             match t with            
             | Some DateTimeContents.Date -> Encoding.toIEncoding Encoding.date
             | Some DateTimeContents.Time -> Encoding.toIEncoding Encoding.time
             | _                          -> Encoding.toIEncoding Encoding.dateTime
-        member _.dateTimeOffset = Encoding.toIEncoding Encoding.dateTimeOffset
-        member _.timeSpan       = Encoding.toIEncoding Encoding.timeSpan
-        member _.decimal        = Encoding.toIEncoding Encoding.decimal
-        member _.float          = Encoding.toIEncoding Encoding.float
-        member _.float32        = Encoding.toIEncoding Encoding.float32
-        member _.int            = Encoding.toIEncoding Encoding.int
-        member _.uint32         = Encoding.toIEncoding Encoding.uint32
-        member _.int64          = Encoding.toIEncoding Encoding.int64
-        member _.uint64         = Encoding.toIEncoding Encoding.uint64
-        member _.int16          = Encoding.toIEncoding Encoding.int16
-        member _.uint16         = Encoding.toIEncoding Encoding.uint16
-        member _.byte           = Encoding.toIEncoding Encoding.byte
-        member _.sbyte          = Encoding.toIEncoding Encoding.sbyte
-        member _.char           = Encoding.toIEncoding Encoding.char
-        member _.bigint         = Encoding.toIEncoding Encoding.bigint
-        member _.guid           = Encoding.toIEncoding Encoding.guid
+        static member dateTimeOffset = Encoding.toIEncoding Encoding.dateTimeOffset
+        static member timeSpan       = Encoding.toIEncoding Encoding.timeSpan
+        static member decimal        = Encoding.toIEncoding Encoding.decimal
+        static member float          = Encoding.toIEncoding Encoding.float
+        static member float32        = Encoding.toIEncoding Encoding.float32
+        static member int            = Encoding.toIEncoding Encoding.int
+        static member uint32         = Encoding.toIEncoding Encoding.uint32
+        static member int64          = Encoding.toIEncoding Encoding.int64
+        static member uint64         = Encoding.toIEncoding Encoding.uint64
+        static member int16          = Encoding.toIEncoding Encoding.int16
+        static member uint16         = Encoding.toIEncoding Encoding.uint16
+        static member byte           = Encoding.toIEncoding Encoding.byte
+        static member sbyte          = Encoding.toIEncoding Encoding.sbyte
+        static member char           = Encoding.toIEncoding Encoding.char
+        static member bigint         = Encoding.toIEncoding Encoding.bigint
+        static member guid           = Encoding.toIEncoding Encoding.guid
 
-        member _.result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
-        member _.choice c1 c2     = Encoding.toIEncoding (Encoding.choice   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
-        member _.choice3 c1 c2 c3 = Encoding.toIEncoding (Encoding.choice3  (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2) (Encoding.ofIEncoding c3))
-        member _.option c         = Encoding.toIEncoding (Encoding.option   (Encoding.ofIEncoding c))
-        member _.array c          = Encoding.toIEncoding (Encoding.array    (Encoding.ofIEncoding c))
-        member _.propertyList c   = Encoding.toIEncoding (Encoding.multiMap (Encoding.ofIEncoding c))
+        static member result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
+        static member choice c1 c2     = Encoding.toIEncoding (Encoding.choice   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
+        static member choice3 c1 c2 c3 = Encoding.toIEncoding (Encoding.choice3  (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2) (Encoding.ofIEncoding c3))
+        static member option c         = Encoding.toIEncoding (Encoding.option   (Encoding.ofIEncoding c))
+        static member array c          = Encoding.toIEncoding (Encoding.array    (Encoding.ofIEncoding c))
+        static member propertyList c   = Encoding.toIEncoding (Encoding.multiMap (Encoding.ofIEncoding c))
 
-        member _.enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<IEncoding, 't> = Encoding.toIEncoding (Encoding.enumD <-> Encoding.enumE)
+        static member enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<Encoding, 't> = Encoding.toIEncoding (Encoding.enumD <-> Encoding.enumE)
 
         member x.getCase =
             match x with

--- a/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
+++ b/src/Fleece.NewtonsoftJson/Fleece.NewtonsoftJson.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>JSON mapper for Newtonsoft Json</Description>
     <DefineConstants>NEWTONSOFT;$(DefineConstants)</DefineConstants>

--- a/src/Fleece.SystemJson/Fleece.SystemJson.fs
+++ b/src/Fleece.SystemJson/Fleece.SystemJson.fs
@@ -81,13 +81,13 @@ type [<Struct>] Encoding = Encoding of JsonValue with
         | js -> Decode.Fail.numExpected (Encoding js)
 
     /// Unwraps the JsonValue inside an IEncoding
-    static member Unwrap (x: IEncoding) = x :?> Encoding |> fun (Encoding s) -> s
+    static member Unwrap (Encoding s) = s
 
     /// Wraps a JsonValue inside an IEncoding
-    static member Wrap x = Encoding x :> IEncoding
+    static member Wrap x = Encoding x
 
-    static member toIEncoding (c: Codec<JsonValue, 't>) : Codec<IEncoding, 't> = c |> Codec.compose ((Encoding.Unwrap >> Ok) <-> Encoding.Wrap)
-    static member ofIEncoding (c: Codec<IEncoding, 't>) : Codec<JsonValue, 't> = c |> Codec.compose ((Encoding.Wrap >> Ok) <-> Encoding.Unwrap)
+    static member toIEncoding (c: Codec<JsonValue, 't>) : Codec<Encoding, 't> = c |> Codec.compose ((Encoding.Unwrap >> Ok) <-> Encoding.Wrap)
+    static member ofIEncoding (c: Codec<Encoding, 't>) : Codec<JsonValue, 't> = c |> Codec.compose ((Encoding.Wrap >> Ok) <-> Encoding.Unwrap)
 
     static member inline jsonObjectOfJson =
         fun (o: JsonValue) ->
@@ -329,39 +329,39 @@ type [<Struct>] Encoding = Encoding of JsonValue with
     static member guid           = Encoding.guidD           <-> Encoding.guidE
 
 
-    interface IEncoding with
-        member _.boolean        = Encoding.toIEncoding Encoding.boolean
-        member _.string         = Encoding.toIEncoding Encoding.string
-        member _.dateTime t     =
+    interface IEncoding<Encoding> with
+        static member boolean        = Encoding.toIEncoding Encoding.boolean
+        static member string         = Encoding.toIEncoding Encoding.string
+        static member dateTime t     =
             match t with            
             | Some DateTimeContents.Date -> Encoding.toIEncoding Encoding.date
             | Some DateTimeContents.Time -> Encoding.toIEncoding Encoding.time
             | _                          -> Encoding.toIEncoding Encoding.dateTime
-        member _.dateTimeOffset = Encoding.toIEncoding Encoding.dateTimeOffset
-        member _.timeSpan       = Encoding.toIEncoding Encoding.timeSpan
-        member _.decimal        = Encoding.toIEncoding Encoding.decimal
-        member _.float          = Encoding.toIEncoding Encoding.float
-        member _.float32        = Encoding.toIEncoding Encoding.float32
-        member _.int            = Encoding.toIEncoding Encoding.int
-        member _.uint32         = Encoding.toIEncoding Encoding.uint32
-        member _.int64          = Encoding.toIEncoding Encoding.int64
-        member _.uint64         = Encoding.toIEncoding Encoding.uint64
-        member _.int16          = Encoding.toIEncoding Encoding.int16
-        member _.uint16         = Encoding.toIEncoding Encoding.uint16
-        member _.byte           = Encoding.toIEncoding Encoding.byte
-        member _.sbyte          = Encoding.toIEncoding Encoding.sbyte
-        member _.char           = Encoding.toIEncoding Encoding.char
-        member _.bigint         = Encoding.toIEncoding Encoding.bigint
-        member _.guid           = Encoding.toIEncoding Encoding.guid
+        static member dateTimeOffset = Encoding.toIEncoding Encoding.dateTimeOffset
+        static member timeSpan       = Encoding.toIEncoding Encoding.timeSpan
+        static member decimal        = Encoding.toIEncoding Encoding.decimal
+        static member float          = Encoding.toIEncoding Encoding.float
+        static member float32        = Encoding.toIEncoding Encoding.float32
+        static member int            = Encoding.toIEncoding Encoding.int
+        static member uint32         = Encoding.toIEncoding Encoding.uint32
+        static member int64          = Encoding.toIEncoding Encoding.int64
+        static member uint64         = Encoding.toIEncoding Encoding.uint64
+        static member int16          = Encoding.toIEncoding Encoding.int16
+        static member uint16         = Encoding.toIEncoding Encoding.uint16
+        static member byte           = Encoding.toIEncoding Encoding.byte
+        static member sbyte          = Encoding.toIEncoding Encoding.sbyte
+        static member char           = Encoding.toIEncoding Encoding.char
+        static member bigint         = Encoding.toIEncoding Encoding.bigint
+        static member guid           = Encoding.toIEncoding Encoding.guid
 
-        member _.result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
-        member _.choice c1 c2     = Encoding.toIEncoding (Encoding.choice   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
-        member _.choice3 c1 c2 c3 = Encoding.toIEncoding (Encoding.choice3  (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2) (Encoding.ofIEncoding c3))
-        member _.option c         = Encoding.toIEncoding (Encoding.option   (Encoding.ofIEncoding c))
-        member _.array c          = Encoding.toIEncoding (Encoding.array    (Encoding.ofIEncoding c))
-        member _.propertyList c   = Encoding.toIEncoding (Encoding.multiMap (Encoding.ofIEncoding c))
+        static member result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
+        static member choice c1 c2     = Encoding.toIEncoding (Encoding.choice   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
+        static member choice3 c1 c2 c3 = Encoding.toIEncoding (Encoding.choice3  (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2) (Encoding.ofIEncoding c3))
+        static member option c         = Encoding.toIEncoding (Encoding.option   (Encoding.ofIEncoding c))
+        static member array c          = Encoding.toIEncoding (Encoding.array    (Encoding.ofIEncoding c))
+        static member propertyList c   = Encoding.toIEncoding (Encoding.multiMap (Encoding.ofIEncoding c))
 
-        member _.enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<IEncoding, 't> = Encoding.toIEncoding (Encoding.enumD <-> Encoding.enumE)
+        static member enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<Encoding, 't> = Encoding.toIEncoding (Encoding.enumD <-> Encoding.enumE)
 
         member x.getCase =
             match x with

--- a/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fs
+++ b/src/Fleece.SystemTextJson/Fleece.SystemTextJson.fs
@@ -160,10 +160,7 @@ and Encoding (j: JsonElementOrWriter) =
         | js -> Decode.Fail.numExpected js
 
     /// Downcasts IEncoding to a SystemTextJson.Encoding
-    static member Unwrap (x: IEncoding) = (x :?> Encoding).get_InnerValue ()
-
-    static member toIEncoding (c: Codec<Encoding, 't>) : Codec<IEncoding, 't> = c |> Codec.upCast
-    static member ofIEncoding (c: Codec<IEncoding, 't>) : Codec<Encoding, 't> = c |> Codec.downCast
+    static member Unwrap (x: Encoding) = x.get_InnerValue ()
 
 
     static member jsonObjectOfJson = function
@@ -400,39 +397,39 @@ and Encoding (j: JsonElementOrWriter) =
     static member guid           = Encoding.guidD           <-> Encoding.guidE
 
 
-    interface IEncoding with
-        member _.boolean        = Encoding.toIEncoding Encoding.boolean
-        member _.string         = Encoding.toIEncoding Encoding.string
-        member _.dateTime t     =
+    interface IEncoding<Encoding> with
+        static member boolean        = Encoding.boolean
+        static member string         = Encoding.string
+        static member dateTime t     =
             match t with            
-            | Some DateTimeContents.Date -> Encoding.toIEncoding Encoding.date
-            | Some DateTimeContents.Time -> Encoding.toIEncoding Encoding.time
-            | _                          -> Encoding.toIEncoding Encoding.dateTime
-        member _.dateTimeOffset = Encoding.toIEncoding Encoding.dateTimeOffset
-        member _.timeSpan       = Encoding.toIEncoding Encoding.timeSpan
-        member _.decimal        = Encoding.toIEncoding Encoding.decimal
-        member _.float          = Encoding.toIEncoding Encoding.float
-        member _.float32        = Encoding.toIEncoding Encoding.float32
-        member _.int            = Encoding.toIEncoding Encoding.int
-        member _.uint32         = Encoding.toIEncoding Encoding.uint32
-        member _.int64          = Encoding.toIEncoding Encoding.int64
-        member _.uint64         = Encoding.toIEncoding Encoding.uint64
-        member _.int16          = Encoding.toIEncoding Encoding.int16
-        member _.uint16         = Encoding.toIEncoding Encoding.uint16
-        member _.byte           = Encoding.toIEncoding Encoding.byte
-        member _.sbyte          = Encoding.toIEncoding Encoding.sbyte
-        member _.char           = Encoding.toIEncoding Encoding.char
-        member _.bigint         = Encoding.toIEncoding Encoding.bigint
-        member _.guid           = Encoding.toIEncoding Encoding.guid
+            | Some DateTimeContents.Date -> Encoding.date
+            | Some DateTimeContents.Time -> Encoding.time
+            | _                          -> Encoding.dateTime
+        static member dateTimeOffset = Encoding.dateTimeOffset
+        static member timeSpan       = Encoding.timeSpan
+        static member decimal        = Encoding.decimal
+        static member float          = Encoding.float
+        static member float32        = Encoding.float32
+        static member int            = Encoding.int
+        static member uint32         = Encoding.uint32
+        static member int64          = Encoding.int64
+        static member uint64         = Encoding.uint64
+        static member int16          = Encoding.int16
+        static member uint16         = Encoding.uint16
+        static member byte           = Encoding.byte
+        static member sbyte          = Encoding.sbyte
+        static member char           = Encoding.char
+        static member bigint         = Encoding.bigint
+        static member guid           = Encoding.guid
 
-        member _.result c1 c2     = Encoding.toIEncoding (Encoding.result   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
-        member _.choice c1 c2     = Encoding.toIEncoding (Encoding.choice   (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2))
-        member _.choice3 c1 c2 c3 = Encoding.toIEncoding (Encoding.choice3  (Encoding.ofIEncoding c1) (Encoding.ofIEncoding c2) (Encoding.ofIEncoding c3))
-        member _.option c         = Encoding.toIEncoding (Encoding.option   (Encoding.ofIEncoding c))
-        member _.array c          = Encoding.toIEncoding (Encoding.array    (Encoding.ofIEncoding c))
-        member _.propertyList c   = Encoding.toIEncoding (Encoding.propList (Encoding.ofIEncoding c))
+        static member result c1 c2     = Encoding.result   c1 c2
+        static member choice c1 c2     = Encoding.choice   c1 c2
+        static member choice3 c1 c2 c3 = Encoding.choice3  c1 c2 c3
+        static member option c         = Encoding.option   c
+        static member array c          = Encoding.array    c
+        static member propertyList c   = Encoding.propList c
         
-        member _.enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<IEncoding, 't> = Encoding.toIEncoding (Encoding.enumD <-> Encoding.enumE)
+        static member enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<Encoding, 't> = (Encoding.enumD <-> Encoding.enumE)
         
         member x.getCase =
             match x with

--- a/src/Fleece/Compatibility.fs
+++ b/src/Fleece/Compatibility.fs
@@ -117,20 +117,20 @@ module Operators =
             | Error x -> Failure x
     
         module Fail =
-            let inline objExpected  (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "Object", a))
-            let inline arrExpected  (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "Array" , a))
-            let inline numExpected  (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "Number", a))
-            let inline strExpected  (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "String", a))
-            let inline boolExpected (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "Bool"  , a))
+            let inline objExpected  (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "Object", a))
+            let inline arrExpected  (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "Array" , a))
+            let inline numExpected  (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "Number", a))
+            let inline strExpected  (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "String", a))
+            let inline boolExpected (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (EncodingCaseMismatch (typeof<'t>, v, "Bool"  , a))
             let [<GeneralizableValue>]nullString<'t> : Result<'t, _> = Error (NullString typeof<'t>)
             let inline count e (x: 'Encoding) =
                 let a =
                     match (Codecs.array (Ok <-> id) |> Codec.decode) x with
                     | Ok a -> a
                     | Error x -> failwithf "Error on error handling: Expected an 'Encoding [] but received %A." x
-                Error (IndexOutOfRange (e, map (fun x -> x :> IEncoding) a))
+                Error (IndexOutOfRange (e, map (fun x -> x :> obj) a))
             let invalidValue (v: 'Encoding) o : Result<'t, _> = Error (InvalidValue (typeof<'t>, v, o))
-            let propertyNotFound p (o: PropertyList<'Encoding>) = Error (PropertyNotFound (p, map (fun x -> x :> IEncoding) o))
+            let propertyNotFound p (o: PropertyList<'Encoding>) = Error (PropertyNotFound (p, map (fun x -> x :> obj) o))
             let parseError s v : Result<'t, _> = Error (ParseError (typeof<'t>, s, v))
 
     
@@ -247,7 +247,7 @@ module Operators =
     let jgetWith ofJson (o: PropertyList<Encoding>) key =
         match o.[key] with
         | value::_ -> ofJson value
-        | _ -> Decode.Fail.propertyNotFound key (o |> map (fun x -> x :> IEncoding))
+        | _ -> Decode.Fail.propertyNotFound key (o |> map (fun x -> x :> obj))
 
     /// Tries to get a value from a Json object.
     /// Returns None if key is not present in the object.

--- a/src/Fleece/Fleece.fs
+++ b/src/Fleece/Fleece.fs
@@ -1,6 +1,7 @@
 namespace Fleece
 
 #nowarn "00042" // retype
+#nowarn "3535" // static interfaces
 
 open System
 open System.Collections.Generic
@@ -120,44 +121,44 @@ and Decoder<'S, 't> = ReaderT<'S, ParseResult<'t>>
 
 and ParseResult<'t> = Result<'t, DecodeError>
 
-and IEncoding =
-    abstract boolean        : Codec<IEncoding, bool>
-    abstract string         : Codec<IEncoding, string>
-    abstract dateTime       : ?dtc: DateTimeContents -> Codec<IEncoding, DateTime>
-    abstract dateTimeOffset : Codec<IEncoding, DateTimeOffset>
-    abstract timeSpan       : Codec<IEncoding, TimeSpan>
+and IEncoding<'Encoding> =
+    static abstract boolean        : Codec<'Encoding, bool>
+    static abstract string         : Codec<'Encoding, string>
+    static abstract dateTime       : ?dtc: DateTimeContents -> Codec<'Encoding, DateTime>
+    static abstract dateTimeOffset : Codec<'Encoding, DateTimeOffset>
+    static abstract timeSpan       : Codec<'Encoding, TimeSpan>
     
-    abstract decimal        : Codec<IEncoding, Decimal>
-    abstract float          : Codec<IEncoding, float>
-    abstract float32        : Codec<IEncoding, float32>
-    abstract int            : Codec<IEncoding, int>
-    abstract uint32         : Codec<IEncoding, uint32>
-    abstract int64          : Codec<IEncoding, int64>
-    abstract uint64         : Codec<IEncoding, uint64>
-    abstract int16          : Codec<IEncoding, int16>
-    abstract uint16         : Codec<IEncoding, uint16>
-    abstract byte           : Codec<IEncoding, byte>
-    abstract sbyte          : Codec<IEncoding, sbyte>
-    abstract char           : Codec<IEncoding, char>
-    abstract bigint         : Codec<IEncoding, bigint>
-    abstract guid           : Codec<IEncoding, Guid>
-    abstract result         : Codec<IEncoding, 't1> -> Codec<IEncoding, 't2> -> Codec<IEncoding, Result<'t1,'t2>>
-    abstract choice         : Codec<IEncoding, 't1> -> Codec<IEncoding, 't2> -> Codec<IEncoding, Choice<'t1,'t2>>
-    abstract choice3        : Codec<IEncoding, 't1> -> Codec<IEncoding, 't2> -> Codec<IEncoding, 't3> -> Codec<IEncoding, Choice<'t1,'t2,'t3>>
-    abstract option         : Codec<IEncoding, 't>  -> Codec<IEncoding, option<'t>>
-    abstract array          : Codec<IEncoding, 't>  -> Codec<IEncoding, 't []>
-    abstract propertyList   : Codec<IEncoding, 't>  -> Codec<IEncoding, PropertyList<'t>>
-    abstract enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> : unit -> Codec<IEncoding, 't>
+    static abstract decimal        : Codec<'Encoding, Decimal>
+    static abstract float          : Codec<'Encoding, float>
+    static abstract float32        : Codec<'Encoding, float32>
+    static abstract int            : Codec<'Encoding, int>
+    static abstract uint32         : Codec<'Encoding, uint32>
+    static abstract int64          : Codec<'Encoding, int64>
+    static abstract uint64         : Codec<'Encoding, uint64>
+    static abstract int16          : Codec<'Encoding, int16>
+    static abstract uint16         : Codec<'Encoding, uint16>
+    static abstract byte           : Codec<'Encoding, byte>
+    static abstract sbyte          : Codec<'Encoding, sbyte>
+    static abstract char           : Codec<'Encoding, char>
+    static abstract bigint         : Codec<'Encoding, bigint>
+    static abstract guid           : Codec<'Encoding, Guid>
+    static abstract result         : Codec<'Encoding, 't1> -> Codec<'Encoding, 't2> -> Codec<'Encoding, Result<'t1,'t2>>
+    static abstract choice         : Codec<'Encoding, 't1> -> Codec<'Encoding, 't2> -> Codec<'Encoding, Choice<'t1,'t2>>
+    static abstract choice3        : Codec<'Encoding, 't1> -> Codec<'Encoding, 't2> -> Codec<'Encoding, 't3> -> Codec<'Encoding, Choice<'t1,'t2,'t3>>
+    static abstract option         : Codec<'Encoding, 't>  -> Codec<'Encoding, option<'t>>
+    static abstract array          : Codec<'Encoding, 't>  -> Codec<'Encoding, 't []>
+    static abstract propertyList   : Codec<'Encoding, 't>  -> Codec<'Encoding, PropertyList<'t>>
+    static abstract enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> : unit -> Codec<'Encoding, 't>
 
     /// Returns a string representing the internal "case" (or type) of the encoding (ie: Array, Object, ... )
     abstract getCase : string
 
 and DecodeError =
-    | EncodingCaseMismatch of DestinationType: Type * Source: IEncoding * ExpectedCase: string * ActualCase: string
+    | EncodingCaseMismatch of DestinationType: Type * Source: obj * ExpectedCase: string * ActualCase: string
     | NullString of DestinationType: Type
-    | IndexOutOfRange of Index: int * Source: IEncoding []
-    | InvalidValue of DestinationType: Type * Source: IEncoding * AdditionalInformation: string
-    | PropertyNotFound of Property: string * Source: PropertyList<IEncoding>
+    | IndexOutOfRange of Index: int * Source: obj []
+    | InvalidValue of DestinationType: Type * Source: obj * AdditionalInformation: string
+    | PropertyNotFound of Property: string * Source: PropertyList<obj>
     | ParseError of DestinationType: Type * Exception: exn * Source: string
     | Uncategorized of Description: string
     | Multiple of DecodeError list
@@ -170,7 +171,7 @@ with
         | _                      -> Multiple [x; y]
     override x.ToString () =
         match x with
-        | EncodingCaseMismatch (t, v: IEncoding, expected, actual) -> sprintf "%s expected but got %s while decoding %s as %s" (string expected) (string actual) (string v) (string t)
+        | EncodingCaseMismatch (t, v, expected, actual) -> sprintf "%s expected but got %s while decoding %s as %s" (string expected) (string actual) (string v) (string t)
         | NullString t            -> sprintf "Expected %s, got null" (string t)
         | IndexOutOfRange (e, a)  -> sprintf "Expected array with %s items, was: %s" (string e) (string a)
         | InvalidValue (t, v, s)  -> sprintf "Value %s is invalid for %s%s" (string v) (string t) (if String.IsNullOrEmpty s then "" else " " + s)
@@ -188,15 +189,15 @@ module Decode =
         | Error x -> Failure x
 
     module Fail =
-        let inline objExpected  (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "Object", a))
-        let inline arrExpected  (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "Array" , a))
-        let inline numExpected  (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "Number", a))
-        let inline strExpected  (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "String", a))
-        let inline boolExpected (v: 'Encoding) : Result<'t, _> = let a = (v :> IEncoding).getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "Bool"  , a))
+        let inline objExpected  (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "Object", a))
+        let inline arrExpected  (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "Array" , a))
+        let inline numExpected  (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "Number", a))
+        let inline strExpected  (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "String", a))
+        let inline boolExpected (v: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> = let a = v.getCase in Error (DecodeError.EncodingCaseMismatch (typeof<'t>, v, "Bool"  , a))
         let [<GeneralizableValue>]nullString<'t> : Result<'t, _> = Error (DecodeError.NullString typeof<'t>)
-        let inline count e (a: 'Encoding []) = Error (DecodeError.IndexOutOfRange (e, map (fun x -> x :> IEncoding) a))
+        let inline count e (a: 'Encoding []) = Error (DecodeError.IndexOutOfRange (e, map (fun x -> x :> obj) a))
         let invalidValue (v: 'Encoding) o : Result<'t, _> = Error (DecodeError.InvalidValue (typeof<'t>, v, o))
-        let propertyNotFound p (o: PropertyList<'Encoding>) = Error (DecodeError.PropertyNotFound (p, map (fun x -> x :> IEncoding) o))
+        let propertyNotFound p (o: PropertyList<'Encoding>) = Error (DecodeError.PropertyNotFound (p, map (fun x -> x :> obj) o))
         
         /// <summary>Creates a parsing error.</summary>
         /// <param name="exn">The source parsing exception.</param>
@@ -205,12 +206,13 @@ module Decode =
         let parseError exn value : Result<'t, _> = Error (DecodeError.ParseError (typeof<'t>, exn, value))
 
 
+(*
 [<Struct>]
-type AdHocEncoding = AdHocEncoding of AdHocEncodingPassing: (IEncoding -> IEncoding) with
+type AdHocEncoding = AdHocEncoding of AdHocEncodingPassing: (obj -> obj) with
 
-    static member ofIEncoding (c1: Codec<IEncoding, 'T>) : _ -> Codec<IEncoding, 'T> =
-        let dec1 (x: IEncoding)   = ReaderT.run c1.Decoder (AdHocEncoding (fun _ -> x) :> IEncoding)
-        let enc1 (i: IEncoding) v = let (AdHocEncoding x) = Const.run (c1.Encoder v) :?> AdHocEncoding in x i
+    static member ofIEncoding (c1: Codec<obj, 'T>) : _ -> Codec<obj, 'T> =
+        let dec1 (x: obj)   = ReaderT.run c1.Decoder (AdHocEncoding (fun _ -> x) :> obj)
+        let enc1 (i: obj) v = let (AdHocEncoding x) = Const.run (c1.Encoder v) :?> AdHocEncoding in x i
         let codec1 i = { Decoder = ReaderT dec1; Encoder = (enc1 i) >> Const }
         codec1
 
@@ -222,63 +224,65 @@ type AdHocEncoding = AdHocEncoding of AdHocEncodingPassing: (IEncoding -> IEncod
     static member ($) (_: AdHocEncoding, (x1, x2, x3, x4, x5, x6, x7)) = fun x -> (AdHocEncoding.ofIEncoding x1 x, AdHocEncoding.ofIEncoding x2 x, AdHocEncoding.ofIEncoding x3 x, AdHocEncoding.ofIEncoding x4 x, AdHocEncoding.ofIEncoding x5 x, AdHocEncoding.ofIEncoding x6 x, AdHocEncoding.ofIEncoding x7 x)
 
     /// Evals the IEncoding parameter to get a concrete Codec.
-    static member toIEncoding (codec: IEncoding -> Codec<IEncoding, 't>) : Codec<IEncoding, 't> =
+    static member toIEncoding<'Encoding, 't when IEncoding<'Encoding>> (codec: obj -> Codec<obj, 't>) : Codec<obj, 't> =
         {
-            Decoder = ReaderT (fun (x: IEncoding) ->
+            Decoder = ReaderT (fun (x: obj) ->
                 let (AdHocEncoding x) = x :?> AdHocEncoding
                 let i = x Unchecked.defaultof<_>
                 ReaderT.run (codec i).Decoder i)
-            Encoder = (fun x -> AdHocEncoding (fun i -> Const.run ((codec i).Encoder x)) :> IEncoding) >> Const
+            Encoder = (fun x -> AdHocEncoding (fun i -> Const.run ((codec i).Encoder x)) :> obj) >> Const
         }
 
     /// Same as toIEncoding but with one parameter.
-    static member toIEncoding1 (codec: IEncoding -> _) codec1 =
+    static member toIEncoding1 (codec: obj -> _) codec1 =
         let codec1 x = AdHocEncoding.ofIEncoding codec1 x
         let codec s = (codec s) (codec1 s)
         AdHocEncoding.toIEncoding codec
 
     /// Same as toIEncoding but with many parameters in tupled form.
-    static member inline toIEncodingN (codec: IEncoding -> _) tupledCodecs =
+    static member inline toIEncodingN (codec: obj -> _) tupledCodecs =
         let codecs = Unchecked.defaultof<AdHocEncoding> $ tupledCodecs
         let codec s = uncurryN (codec s) (codecs s)
         AdHocEncoding.toIEncoding codec
 
-    interface IEncoding with
-        member _.boolean        = AdHocEncoding.toIEncoding (fun x -> x.boolean)
-        member _.string         = AdHocEncoding.toIEncoding (fun x -> x.string)
-        member _.dateTime ?dtc  = AdHocEncoding.toIEncoding (fun x -> match dtc with Some d -> x.dateTime d | None -> x.dateTime ())
-        member _.dateTimeOffset = AdHocEncoding.toIEncoding (fun x -> x.dateTimeOffset)
-        member _.timeSpan       = AdHocEncoding.toIEncoding (fun x -> x.timeSpan)
-        member _.decimal        = AdHocEncoding.toIEncoding (fun x -> x.decimal)
-        member _.float          = AdHocEncoding.toIEncoding (fun x -> x.float)
-        member _.float32        = AdHocEncoding.toIEncoding (fun x -> x.float32)
-        member _.int            = AdHocEncoding.toIEncoding (fun x -> x.int)
-        member _.uint32         = AdHocEncoding.toIEncoding (fun x -> x.uint32)
-        member _.int64          = AdHocEncoding.toIEncoding (fun x -> x.int64)
-        member _.uint64         = AdHocEncoding.toIEncoding (fun x -> x.uint64)
-        member _.int16          = AdHocEncoding.toIEncoding (fun x -> x.int16)
-        member _.uint16         = AdHocEncoding.toIEncoding (fun x -> x.uint16)
-        member _.byte           = AdHocEncoding.toIEncoding (fun x -> x.byte)
-        member _.sbyte          = AdHocEncoding.toIEncoding (fun x -> x.sbyte)
-        member _.char           = AdHocEncoding.toIEncoding (fun x -> x.char)
-        member _.bigint         = AdHocEncoding.toIEncoding (fun x -> x.bigint)
-        member _.guid           = AdHocEncoding.toIEncoding (fun x -> x.guid)
-        member _.enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<IEncoding, 't> = AdHocEncoding.toIEncoding (fun x -> x.enum ())
+    interface IEncoding<AdHocEncoding> with
+        static member boolean        = AdHocEncoding.toIEncoding (fun x -> x.boolean)
+        static member string         = AdHocEncoding.toIEncoding (fun x -> x.string)
+        static member dateTime ?dtc  = AdHocEncoding.toIEncoding (fun x -> match dtc with Some d -> x.dateTime d | None -> x.dateTime ())
+        static member dateTimeOffset = AdHocEncoding.toIEncoding (fun x -> x.dateTimeOffset)
+        static member timeSpan       = AdHocEncoding.toIEncoding (fun x -> x.timeSpan)
+        static member decimal        = AdHocEncoding.toIEncoding (fun x -> x.decimal)
+        static member float          = AdHocEncoding.toIEncoding (fun x -> x.float)
+        static member float32        = AdHocEncoding.toIEncoding (fun x -> x.float32)
+        static member int            = AdHocEncoding.toIEncoding (fun x -> x.int)
+        static member uint32         = AdHocEncoding.toIEncoding (fun x -> x.uint32)
+        static member int64          = AdHocEncoding.toIEncoding (fun x -> x.int64)
+        static member uint64         = AdHocEncoding.toIEncoding (fun x -> x.uint64)
+        static member int16          = AdHocEncoding.toIEncoding (fun x -> x.int16)
+        static member uint16         = AdHocEncoding.toIEncoding (fun x -> x.uint16)
+        static member byte           = AdHocEncoding.toIEncoding (fun x -> x.byte)
+        static member sbyte          = AdHocEncoding.toIEncoding (fun x -> x.sbyte)
+        static member char           = AdHocEncoding.toIEncoding (fun x -> x.char)
+        static member bigint         = AdHocEncoding.toIEncoding (fun x -> x.bigint)
+        static member guid           = AdHocEncoding.toIEncoding (fun x -> x.guid)
+        static member enum<'t, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType> () : Codec<IEncoding, 't> = AdHocEncoding.toIEncoding (fun x -> x.enum ())
 
-        member _.result c1 c2     = AdHocEncoding.toIEncodingN (fun x -> x.result)  (c1, c2)
-        member _.choice c1 c2     = AdHocEncoding.toIEncodingN (fun x -> x.choice)  (c1, c2)
-        member _.choice3 c1 c2 c3 = AdHocEncoding.toIEncodingN (fun x -> x.choice3) (c1, c2, c3)
-        member _.option c         = AdHocEncoding.toIEncoding1 (fun x -> x.option) c
-        member _.array c          = AdHocEncoding.toIEncoding1 (fun x -> x.array)  c
-        member _.propertyList c   = AdHocEncoding.toIEncoding1 (fun x -> x.propertyList) c
+        static member result c1 c2     = AdHocEncoding.toIEncodingN (fun x -> x.result)  (c1, c2)
+        static member choice c1 c2     = AdHocEncoding.toIEncodingN (fun x -> x.choice)  (c1, c2)
+        static member choice3 c1 c2 c3 = AdHocEncoding.toIEncodingN (fun x -> x.choice3) (c1, c2, c3)
+        static member option c         = AdHocEncoding.toIEncoding1 (fun x -> x.option) c
+        static member array c          = AdHocEncoding.toIEncoding1 (fun x -> x.array)  c
+        static member propertyList c   = AdHocEncoding.toIEncoding1 (fun x -> x.propertyList) c
 
         member x.getCase =
             // Normally it won't get called as errors will access the getCase from the wrapped AdHocEncoding
-            let (AdHocEncoding f) = x
-            let i = f Unchecked.defaultof<IEncoding>
-            if not (Object.ReferenceEquals (i, null)) then i.getCase
-            else "Unknown case"
+            //let (AdHocEncoding f) = x
+            //let i = f Unchecked.defaultof<IEncoding>
+            //if not (Object.ReferenceEquals (i, null)) then i.getCase
+            //else "Unknown case"
+            "Unknown case"
 
+*)
 /// Functions operating on Codecs
 module Codec =
 
@@ -319,15 +323,15 @@ module Codec =
                 | Ok a    -> Ok (f a))
             (encode field)
 
-    let downCast<'t, 'S when 'S :> IEncoding> (x: Codec<IEncoding, 't> ) : Codec<'S, 't> =
-        create
-            (fun (p: 'S) -> decode x (p :> IEncoding))
-            (fun (p: 't) -> encode x p :?> 'S)
-
-    let upCast<'t, 'S when 'S :> IEncoding> (x: Codec<'S, 't>) : Codec<IEncoding, 't> =
-        create
-            (fun (p: IEncoding) -> decode x (p :?> 'S))
-            (fun (p: 't) -> encode x p :> IEncoding)
+    // let downCast<'t, 'S when 'S :> IEncoding> (x: Codec<IEncoding, 't> ) : Codec<'S, 't> =
+    //     create
+    //         (fun (p: 'S) -> decode x (p :> IEncoding))
+    //         (fun (p: 't) -> encode x p :?> 'S)
+    // 
+    // let upCast<'t, 'S when 'S :> IEncoding> (x: Codec<'S, 't>) : Codec<IEncoding, 't> =
+    //     create
+    //         (fun (p: IEncoding) -> decode x (p :?> 'S))
+    //         (fun (p: 't) -> encode x p :> IEncoding)
 
     
     [<Obsolete("This function is no longer needed. You can safely remove it.")>]
@@ -376,55 +380,55 @@ type Codec<'S1, 'S2, 't1, 't2> with
 
 module Codecs =
 
-    let private instance<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = new 'Encoding ()
+    // let private instance<'Encoding when IEncoding<'Encoding>> = new 'Encoding ()
     let private (<->) decoder encoder : Codec<_, _> = Codec.create decoder encoder
 
-    let [<GeneralizableValue>] boolean<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>        = instance<'Encoding>.boolean        |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] bigint<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>         = instance<'Encoding>.bigint         |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] guid<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>           = instance<'Encoding>.guid           |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] char<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>           = instance<'Encoding>.char           |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] byte<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>           = instance<'Encoding>.byte           |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] sbyte<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>          = instance<'Encoding>.sbyte          |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] uint16<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>         = instance<'Encoding>.uint16         |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] uint32<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>         = instance<'Encoding>.uint32         |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] uint64<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>         = instance<'Encoding>.uint64         |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] int16<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>          = instance<'Encoding>.int16          |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] int<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>            = instance<'Encoding>.int            |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] int64<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>          = instance<'Encoding>.int64          |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] decimal<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>        = instance<'Encoding>.decimal        |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] float32<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>        = instance<'Encoding>.float32        |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] float<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>          = instance<'Encoding>.float          |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] string<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>         = instance<'Encoding>.string         |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] dateTime<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>       = instance<'Encoding>.dateTime ()    |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] dateTimeOffset<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = instance<'Encoding>.dateTimeOffset |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] timeSpan<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)>       = instance<'Encoding>.timeSpan       |> Codec.downCast : Codec<'Encoding, _>
-    let array        (codec: Codec<'Encoding, 'a>) = instance<'Encoding>.array (Codec.upCast codec) |> Codec.downCast : Codec<'Encoding, array<'a>>
-    let list         (codec: Codec<'Encoding, 'a>) = (Ok << Array.toList <-> Array.ofList) >.> array codec
-    let set          (codec: Codec<'Encoding, 'a>) = (Ok << Set <-> Array.ofSeq)           >.> array codec
-    let nonEmptyList (codec: Codec<'Encoding, 'a>) = (Array.toList >> NonEmptyList.tryOfList >> Option.toResultWith (DecodeError.Uncategorized "List is empty") <-> Array.ofSeq) >.> array codec
-    let nonEmptySet  (codec: Codec<'Encoding, 'a>) = (Set >> NonEmptySet.tryOfSet >> Option.toResultWith (DecodeError.Uncategorized "Set is empty") <-> Array.ofSeq) >.> array codec
-    let resizeArray  (codec: Codec<'Encoding, 'a>) = Codec.compose (array codec) (Ok << ResizeArray <-> Array.ofSeq)
-    let propList     (codec: Codec<'Encoding, 'a>) = instance<'Encoding>.propertyList (Codec.upCast codec) |> Codec.downCast : Codec<'Encoding, PropertyList<'a>>
-    let propMap      (codec: Codec<'Encoding, 'a>) = (Ok << Map.ofSeq << PropertyList.ToSeq <-> (Map.toArray >> PropertyList)) >.> propList codec
+    let [<GeneralizableValue>] boolean<'Encoding  when IEncoding<'Encoding>> = 'Encoding.boolean
+    let [<GeneralizableValue>] bigint<'Encoding   when IEncoding<'Encoding>> = 'Encoding.bigint
+    let [<GeneralizableValue>] guid<'Encoding     when IEncoding<'Encoding>> = 'Encoding.guid
+    let [<GeneralizableValue>] char<'Encoding     when IEncoding<'Encoding>> = 'Encoding.char
+    let [<GeneralizableValue>] byte<'Encoding     when IEncoding<'Encoding>> = 'Encoding.byte
+    let [<GeneralizableValue>] sbyte<'Encoding    when IEncoding<'Encoding>> = 'Encoding.sbyte
+    let [<GeneralizableValue>] uint16<'Encoding   when IEncoding<'Encoding>> = 'Encoding.uint16
+    let [<GeneralizableValue>] uint32<'Encoding   when IEncoding<'Encoding>> = 'Encoding.uint32
+    let [<GeneralizableValue>] uint64<'Encoding   when IEncoding<'Encoding>> = 'Encoding.uint64
+    let [<GeneralizableValue>] int16<'Encoding    when IEncoding<'Encoding>> = 'Encoding.int16
+    let [<GeneralizableValue>] int<'Encoding      when IEncoding<'Encoding>> = 'Encoding.int
+    let [<GeneralizableValue>] int64<'Encoding    when IEncoding<'Encoding>> = 'Encoding.int64
+    let [<GeneralizableValue>] decimal<'Encoding  when IEncoding<'Encoding>> = 'Encoding.decimal
+    let [<GeneralizableValue>] float32<'Encoding  when IEncoding<'Encoding>> = 'Encoding.float32
+    let [<GeneralizableValue>] float<'Encoding    when IEncoding<'Encoding>> = 'Encoding.float
+    let [<GeneralizableValue>] string<'Encoding   when IEncoding<'Encoding>> = 'Encoding.string
+    let [<GeneralizableValue>] dateTime<'Encoding when IEncoding<'Encoding>> = 'Encoding.dateTime ()
+    let [<GeneralizableValue>] dateTimeOffset<'Encoding when IEncoding<'Encoding>> = 'Encoding.dateTimeOffset
+    let [<GeneralizableValue>] timeSpan<'Encoding when IEncoding<'Encoding>> = 'Encoding.timeSpan
+    let array        (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = 'Encoding.array codec
+    let list         (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = (Ok << Array.toList <-> Array.ofList) >.> array codec
+    let set          (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = (Ok << Set <-> Array.ofSeq)           >.> array codec
+    let nonEmptyList (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = (Array.toList >> NonEmptyList.tryOfList >> Option.toResultWith (DecodeError.Uncategorized "List is empty") <-> Array.ofSeq) >.> array codec
+    let nonEmptySet  (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = (Set >> NonEmptySet.tryOfSet >> Option.toResultWith (DecodeError.Uncategorized "Set is empty") <-> Array.ofSeq) >.> array codec
+    let resizeArray  (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = Codec.compose (array codec) (Ok << ResizeArray <-> Array.ofSeq)
+    let propList     (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = 'Encoding.propertyList codec
+    let propMap      (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = (Ok << Map.ofSeq << PropertyList.ToSeq <-> (Map.toArray >> PropertyList)) >.> propList codec
     let propDictionary  (codec: Codec<'Encoding, 'a>) = (Ok << Dictionary.ofSeq << PropertyList.ToSeq <-> (Dictionary.toArray >> PropertyList)) >.> propList codec
-    let nonEmptyPropMap (codec: Codec<'Encoding, 'a>) = (PropertyList.ToSeq >> Map.ofSeq >> NonEmptyMap.tryOfMap >> Option.toResultWith (DecodeError.Uncategorized "Map is empty") <-> (NonEmptyMap.toArray >> PropertyList)) >.> propList codec    
-    let option   (codec: Codec<'Encoding, 'a>) = instance<'Encoding>.option (Codec.upCast codec) |> Codec.downCast : Codec<'Encoding, option<'a>>
-    let voption  (codec: Codec<'Encoding, 'a>) = (Ok << Option.toValueOption <-> Option.ofValueOption) >.> option codec : Codec<'Encoding, voption<'a>>
-    let nullable (codec: Codec<'Encoding, 'a>) = (Ok << Option.toNullable    <-> Option.ofNullable   ) >.> option codec : Codec<'Encoding, Nullable<'a>>
-    let result  (codec1: Codec<'Encoding, 'a>)  (codec2: Codec<'Encoding, 'b>) = instance<'Encoding>.result (Codec.upCast codec1) (Codec.upCast codec2) |> Codec.downCast : Codec<'Encoding, Result<'a,'b>>
-    let choice  (codec1: Codec<'Encoding, 'a>)  (codec2: Codec<'Encoding, 'b>) = instance<'Encoding>.choice (Codec.upCast codec1) (Codec.upCast codec2) |> Codec.downCast : Codec<'Encoding, Choice<'a,'b>>
-    let choice3 (codec1: Codec<'Encoding, 't1>) (codec2: Codec<'Encoding, 't2>) (codec3: Codec<'Encoding, 't3>) = instance<'Encoding>.choice3 (Codec.upCast codec1) (Codec.upCast codec2) (Codec.upCast codec3) |> Codec.downCast : Codec<'Encoding, _>
+    let nonEmptyPropMap (codec: Codec<'Encoding, 'a>) = (PropertyList.ToSeq >> Map.ofSeq >> NonEmptyMap.tryOfMap >> Option.toResultWith (DecodeError.Uncategorized "Map is empty") <-> (NonEmptyMap.toArray >> PropertyList)) >.> propList codec
+    let option   (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = 'Encoding.option codec : Codec<'Encoding, option<'a>>
+    let voption  (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = (Ok << Option.toValueOption <-> Option.ofValueOption) >.> option codec : Codec<'Encoding, voption<'a>>
+    let nullable (codec: Codec<'Encoding, 'a> when IEncoding<'Encoding>) = (Ok << Option.toNullable    <-> Option.ofNullable   ) >.> option codec : Codec<'Encoding, Nullable<'a>>
+    let result  (codec1: Codec<'Encoding, 'a> when IEncoding<'Encoding>)  (codec2: Codec<'Encoding, 'b>) = 'Encoding.result codec1 codec2 : Codec<'Encoding, Result<'a,'b>>
+    let choice  (codec1: Codec<'Encoding, 'a> when IEncoding<'Encoding>)  (codec2: Codec<'Encoding, 'b>) = 'Encoding.choice codec1 codec2 : Codec<'Encoding, Choice<'a,'b>>
+    let choice3 (codec1: Codec<'Encoding, 't1> when IEncoding<'Encoding>) (codec2: Codec<'Encoding, 't2>) (codec3: Codec<'Encoding, 't3>) = 'Encoding.choice3 codec1 codec2 codec3 : Codec<'Encoding, _>
     
     #if NET6_0_OR_GREATER
-    let [<GeneralizableValue>] date<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = (Ok << DateOnly.FromDateTime <-> fun x -> x.ToDateTime (TimeOnly(0,0), DateTimeKind.Utc)) >.> instance<'Encoding>.dateTime DateTimeContents.Date |> Codec.downCast : Codec<'Encoding, _>
-    let [<GeneralizableValue>] time<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = (Ok << TimeOnly.FromDateTime <-> fun x -> DateTime x.Ticks)                               >.> instance<'Encoding>.dateTime DateTimeContents.Time |> Codec.downCast : Codec<'Encoding, _>
+    let [<GeneralizableValue>] date<'Encoding when IEncoding<'Encoding>> = (Ok << DateOnly.FromDateTime <-> fun x -> x.ToDateTime (TimeOnly(0,0), DateTimeKind.Utc)) >.> 'Encoding.dateTime DateTimeContents.Date : Codec<'Encoding, _>
+    let [<GeneralizableValue>] time<'Encoding when IEncoding<'Encoding>> = (Ok << TimeOnly.FromDateTime <-> fun x -> DateTime x.Ticks)                               >.> 'Encoding.dateTime DateTimeContents.Time : Codec<'Encoding, _>
     #endif
 
     let [<GeneralizableValue>]id<'T> : Codec<'T, 'T> = Ok <-> id
 
     [<ComponentModel.EditorBrowsable(ComponentModel.EditorBrowsableState.Never)>]
     module Internals =
-        let inline createTuple c (t: 'Encoding [] -> _ when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)) (a : 'Encoding []) = if length a <> c then Decode.Fail.count c a else t a
+        let inline createTuple c (t: 'Encoding [] -> _ when IEncoding<'Encoding>) (a : 'Encoding []) = if length a <> c then Decode.Fail.count c a else t a
 
         let ptuple1  (codec1: Codec<'Encoding, 't1>) =
             let tuple1D (decoder1: 'Encoding -> ParseResult<'a>) : 'Encoding [] -> ParseResult<Tuple<'a>> = createTuple 1 (fun a -> Result.map (fun a -> (Tuple<_> a)) (decoder1 a.[0]) )
@@ -468,7 +472,7 @@ module Codecs =
         
     open Internals
     
-    let [<GeneralizableValue>] unit<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> =
+    let [<GeneralizableValue>] unit<'Encoding when IEncoding<'Encoding>> =
         let tuple0D : 'Encoding [] -> ParseResult<unit> = createTuple 0 (fun _ -> Ok ())
         let tuple0E () = [||]
         (tuple0D <-> tuple0E)
@@ -490,8 +494,8 @@ module Codecs =
     let vtuple6  (codec1: Codec<'Encoding, 't1>) (codec2: Codec<'Encoding, 't2>) (codec3: Codec<'Encoding, 't3>) (codec4: Codec<'Encoding, 't4>) (codec5: Codec<'Encoding, 't5>) (codec6: Codec<'Encoding, 't6>) = ((Ok << fun (x1, x2, x3, x4, x5, x6) -> struct (x1, x2, x3, x4, x5, x6)) <-> fun (struct (x1, x2, x3, x4, x5, x6)) -> (x1, x2, x3, x4, x5, x6)) >.> tuple6 codec1 codec2 codec3 codec4 codec5 codec6: Codec<'Encoding, _>
     let vtuple7  (codec1: Codec<'Encoding, 't1>) (codec2: Codec<'Encoding, 't2>) (codec3: Codec<'Encoding, 't3>) (codec4: Codec<'Encoding, 't4>) (codec5: Codec<'Encoding, 't5>) (codec6: Codec<'Encoding, 't6>) (codec7: Codec<'Encoding, 't7>) = ((Ok << fun (x1, x2, x3, x4, x5, x6, x7) -> struct (x1, x2, x3, x4, x5, x6, x7)) <-> fun (struct (x1, x2, x3, x4, x5, x6, x7)) -> (x1, x2, x3, x4, x5, x6, x7)) >.> tuple7 codec1 codec2 codec3 codec4 codec5 codec6 codec7: Codec<'Encoding, _>
 
-    let enum<'Encoding, 't, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType and 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = instance<'Encoding>.enum () |> Codec.downCast : Codec<'Encoding, 't>
-    let [<GeneralizableValue>] base64Bytes<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> = (Ok << Convert.FromBase64String <-> Convert.ToBase64String) >.> instance<'Encoding>.string |> Codec.downCast : Codec<'Encoding, _>
+    let enum<'Encoding, 't, 'u when 't : enum<'u> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType and IEncoding<'Encoding>> = 'Encoding.enum () : Codec<'Encoding, 't>
+    let [<GeneralizableValue>] base64Bytes<'Encoding when IEncoding<'Encoding>> = (Ok << Convert.FromBase64String <-> Convert.ToBase64String) >.> 'Encoding.string : Codec<'Encoding, _>
 
     #if !FABLE_COMPILER
     let arraySegment (codec: Codec<'Encoding, 'a>) = (Ok << ArraySegment<_> << Seq.toArray <-> ArraySegment.toArray) >.> array codec
@@ -604,7 +608,7 @@ module Internals =
         static member GetCodec (_: OpEncode, _: GetCodec, _, _: OpEncode) = invalidOp "Fleece internal error: this code should be unreachable." : Codec<'Encoding, OpEncode>
 
         /// Invoker for Codec
-        static member inline Invoke<'Encoding, 'Operation, .. when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> (x: 't) : Codec<'Encoding, ^t> =
+        static member inline Invoke<'Encoding, 'Operation, .. when IEncoding<'Encoding>> (x: 't) : Codec<'Encoding, ^t> =
             let inline call (a: ^a, b: ^b) = ((^a or ^b) : (static member GetCodec: ^b * ^a* ^a * _ -> Codec<'Encoding, ^t>) b, a, a, Unchecked.defaultof<'Operation>)
             call (Unchecked.defaultof<GetCodec>, x)
 
@@ -612,7 +616,7 @@ module Internals =
         inherit GetCodec
      
         /// Invoker for Codec, originated from a Decoder Invoker.
-        static member inline Invoke<'Encoding, 'Operation, .. when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> (x: 't) : Codec<'Encoding, ^t> =
+        static member inline Invoke<'Encoding, 'Operation, .. when IEncoding<'Encoding>> (x: 't) : Codec<'Encoding, ^t> =
             let inline call (a: ^a, b: ^b) = ((^a or ^b) : (static member GetCodec: ^b * ^a* ^a * _ -> Codec<'Encoding, ^t>) b, a, a, Unchecked.defaultof<'Operation>)
             call (Unchecked.defaultof<GetDec>, x)
 
@@ -620,30 +624,30 @@ module Internals =
         inherit GetDec
 
         /// Invoker for Codec, originated from an Encoder Invoker.
-        static member inline Invoke<'Encoding, 'Operation, .. when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> (x: 't) : Codec<'Encoding, ^t> =
+        static member inline Invoke<'Encoding, 'Operation, .. when IEncoding<'Encoding>> (x: 't) : Codec<'Encoding, ^t> =
             let inline call (a: ^a, b: ^b) = ((^a or ^b) : (static member GetCodec: ^b * ^a* ^a * _ -> Codec<'Encoding, ^t>) b, a, a, Unchecked.defaultof<'Operation>)
             call (Unchecked.defaultof<GetEnc>, x)
 
     type GetCodec with
-        static member inline GetCodec (_: ValueTuple<'a> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, ValueTuple<'a>> = Codecs.vtuple1 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)
-        static member inline GetCodec (_: Tuple<'a> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Tuple<'a>> = Codecs.tuple1 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)
-        static member inline GetCodec (_: 'a Id1    when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, _, _: 'Operation) = Ok (Id1<'a> Unchecked.defaultof<'a>), Map.empty
+        static member inline GetCodec (_: ValueTuple<'a> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, ValueTuple<'a>> = Codecs.vtuple1 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)
+        static member inline GetCodec (_: Tuple<'a> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Tuple<'a>> = Codecs.tuple1 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)
+        static member inline GetCodec (_: 'a Id1    when IEncoding<'Encoding>, _: GetCodec, _, _: 'Operation) = Ok (Id1<'a> Unchecked.defaultof<'a>), Map.empty
 
     
     type GetArrCodec =
         interface IDefault0
 
-        static member inline GetArrCodec (_: Id2<'a> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _, _: 'Operation) : Codec<'Encoding [], Id2<'a>> = Unchecked.defaultof<_>
+        static member inline GetArrCodec (_: Id2<'a> when IEncoding<'Encoding>, _, _: 'Operation) : Codec<'Encoding [], Id2<'a>> = Unchecked.defaultof<_>
 
-        static member inline GetArrCodec (_: Tuple<'a> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _, _: 'Operation) : Codec<'Encoding [], Tuple<'a>> =
+        static member inline GetArrCodec (_: Tuple<'a> when IEncoding<'Encoding>, _, _: 'Operation) : Codec<'Encoding [], Tuple<'a>> =
             Codecs.Internals.ptuple1 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)
 
-        static member inline Invoke<'Encoding, 'Operation, .. when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> (x: 't) : Codec<'Encoding [], ^t> =
+        static member inline Invoke<'Encoding, 'Operation, .. when IEncoding<'Encoding>> (x: 't) : Codec<'Encoding [], ^t> =
             let inline call (a: ^a, b: ^b) = ((^a or ^b) : (static member GetArrCodec: ^b * ^a * _ -> Codec<'Encoding [], ^t>) b, a, Unchecked.defaultof<'Operation>)
             call (Unchecked.defaultof<GetArrCodec>, x)
 
     type GetArrCodec with
-        static member inline GetArrCodec (_:'tuple when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding) , _: 'GetArrCodec, _: 'Operation) : Codec<'Encoding [], 'tuple> =                
+        static member inline GetArrCodec (_:'tuple when IEncoding<'Encoding> , _: 'GetArrCodec, _: 'Operation) : Codec<'Encoding [], 'tuple> =                
             CodecCache<'Operation, 'Encoding [], 'tuple>.Run (fun () ->
                 let c1 = GetCodec.Invoke<   'Encoding, 'Operation, _> Unchecked.defaultof<'t1>
                 let c2 = GetCodec.Invoke<   'Encoding, 'Operation, _> Unchecked.defaultof<'t2>
@@ -664,7 +668,7 @@ module Internals =
                         let (t7: 't7 ParseResult) = (Codec.decode c7) (x.[6])
                         let (tr: 'tr ParseResult) = (Codec.decode cr) (x.[7..])
                         match tr with
-                        | Error (DecodeError.IndexOutOfRange (i, _)) -> Error (DecodeError.IndexOutOfRange (i + 8, Array.map (fun x -> x :> IEncoding) x))
+                        | Error (DecodeError.IndexOutOfRange (i, _)) -> Error (DecodeError.IndexOutOfRange (i + 8, Array.map (fun x -> x :> obj) x))
                         | _ -> curryN (Tuple<_,_,_,_,_,_,_,_> >> retype : _ -> 'tuple) <!> t1 <*> t2 <*> t3 <*> t4 <*> t5 <*> t6 <*> t7 <*> tr)
                     (fun (t: 'tuple) ->
                         let t1 = (Codec.encode c1) (^tuple: (member Item1: 't1) t)
@@ -679,34 +683,34 @@ module Internals =
 
 
     type GetArrCodec with
-        static member inline GetArrCodec (_: 'a * 'b                          when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _, _: 'Operation) : Codec<'Encoding [], 'a * 'b                         > = (fun () -> Codecs.Internals.ptuple2 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>)                                                                                                                                                                                                                                                                                                                                           ) |> CodecCache<'Operation, 'Encoding [], _>.Run
-        static member inline GetArrCodec (_: 'a * 'b * 'c                     when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c                    > = (fun () -> Codecs.Internals.ptuple3 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>)                                                                                                                                                                                                                                                                         ) |> CodecCache<'Operation, 'Encoding [], _>.Run
-        static member inline GetArrCodec (_: 'a * 'b * 'c * 'd                when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c * 'd               > = (fun () -> Codecs.Internals.ptuple4 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>)                                                                                                                                                                                                       ) |> CodecCache<'Operation, 'Encoding [], _>.Run
-        static member inline GetArrCodec (_: 'a * 'b * 'c * 'd * 'e           when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c * 'd * 'e          > = (fun () -> Codecs.Internals.ptuple5 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>)                                                                                                                                     ) |> CodecCache<'Operation, 'Encoding [], _>.Run
-        static member inline GetArrCodec (_: 'a * 'b * 'c * 'd * 'e * 'f      when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c * 'd * 'e * 'f     > = (fun () -> Codecs.Internals.ptuple6 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'f>)                                                                   ) |> CodecCache<'Operation, 'Encoding [], _>.Run
-        static member inline GetArrCodec (_: 'a * 'b * 'c * 'd * 'e * 'f * 'g when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c * 'd * 'e * 'f * 'g> = (fun () -> Codecs.Internals.ptuple7 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'f>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'g>) ) |> CodecCache<'Operation, 'Encoding [], _>.Run
+        static member inline GetArrCodec (_: 'a * 'b                          when IEncoding<'Encoding>, _, _: 'Operation) : Codec<'Encoding [], 'a * 'b                         > = (fun () -> Codecs.Internals.ptuple2 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>)                                                                                                                                                                                                                                                                                                                                           ) |> CodecCache<'Operation, 'Encoding [], _>.Run
+        static member inline GetArrCodec (_: 'a * 'b * 'c                     when IEncoding<'Encoding>, _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c                    > = (fun () -> Codecs.Internals.ptuple3 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>)                                                                                                                                                                                                                                                                         ) |> CodecCache<'Operation, 'Encoding [], _>.Run
+        static member inline GetArrCodec (_: 'a * 'b * 'c * 'd                when IEncoding<'Encoding>, _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c * 'd               > = (fun () -> Codecs.Internals.ptuple4 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>)                                                                                                                                                                                                       ) |> CodecCache<'Operation, 'Encoding [], _>.Run
+        static member inline GetArrCodec (_: 'a * 'b * 'c * 'd * 'e           when IEncoding<'Encoding>, _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c * 'd * 'e          > = (fun () -> Codecs.Internals.ptuple5 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>)                                                                                                                                     ) |> CodecCache<'Operation, 'Encoding [], _>.Run
+        static member inline GetArrCodec (_: 'a * 'b * 'c * 'd * 'e * 'f      when IEncoding<'Encoding>, _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c * 'd * 'e * 'f     > = (fun () -> Codecs.Internals.ptuple6 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'f>)                                                                   ) |> CodecCache<'Operation, 'Encoding [], _>.Run
+        static member inline GetArrCodec (_: 'a * 'b * 'c * 'd * 'e * 'f * 'g when IEncoding<'Encoding>, _, _: 'Operation) : Codec<'Encoding [], 'a * 'b * 'c * 'd * 'e * 'f * 'g> = (fun () -> Codecs.Internals.ptuple7 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'f>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'g>) ) |> CodecCache<'Operation, 'Encoding [], _>.Run
 
     
-    type GetCodec with static member inline GetCodec (_: Result<'a, 'b> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Result<'a,'b>> = (fun () -> Codecs.result (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>)) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: Choice<'a, 'b> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Choice<'a,'b>> = (fun () -> Codecs.choice (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>)) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: Choice<'a, 'b, 'c> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Choice<'a,'b,'c>> = (fun () -> Codecs.choice3 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>)) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: 'a voption  when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, voption<'a>>  = (fun () -> Codecs.voption  (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: 'a option   when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, option<'a>>   = (fun () -> Codecs.option   (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: 'a Nullable when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Nullable<'a>> = (fun () -> Codecs.nullable (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: NonEmptyList<'T> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, NonEmptyList<'T>> = (fun () -> Codecs.nonEmptyList (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'T>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: Result<'a, 'b> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Result<'a,'b>> = (fun () -> Codecs.result (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: Choice<'a, 'b> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Choice<'a,'b>> = (fun () -> Codecs.choice (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: Choice<'a, 'b, 'c> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Choice<'a,'b,'c>> = (fun () -> Codecs.choice3 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: 'a voption  when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, voption<'a>>  = (fun () -> Codecs.voption  (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: 'a option   when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, option<'a>>   = (fun () -> Codecs.option   (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: 'a Nullable when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Nullable<'a>> = (fun () -> Codecs.nullable (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: NonEmptyList<'T> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, NonEmptyList<'T>> = (fun () -> Codecs.nonEmptyList (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'T>)) |> CodecCache<'Operation, 'Encoding, _>.Run
 
     type GetCodec with
-        static member inline GetCodec (_: 'a array  when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, array<'a>> = Codecs.array (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)
+        static member inline GetCodec (_: 'a array  when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, array<'a>> = Codecs.array (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)
 
         #if !FABLE_COMPILER
-        static member inline GetCodec (_: ArraySegment<'a>  when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, ArraySegment<'a>> = (fun () -> Codecs.arraySegment (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+        static member inline GetCodec (_: ArraySegment<'a>  when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, ArraySegment<'a>> = (fun () -> Codecs.arraySegment (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
         #endif
 
-    type GetCodec with static member inline GetCodec (_: list<'a>        when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _          , c, _: 'Operation) : Codec<'Encoding, list<'a>>        = (fun () -> Codecs.list        (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: Set<'a>         when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Set<'a>>         = (fun () -> Codecs.set         (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: NonEmptySet<'a> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, NonEmptySet<'a>> = (fun () -> Codecs.nonEmptySet (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: list<'a>        when IEncoding<'Encoding>, _          , c, _: 'Operation) : Codec<'Encoding, list<'a>>        = (fun () -> Codecs.list        (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: Set<'a>         when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Set<'a>>         = (fun () -> Codecs.set         (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: NonEmptySet<'a> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, NonEmptySet<'a>> = (fun () -> Codecs.nonEmptySet (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
     type GetCodec with
-        static member inline GetCodec (_: Map<'K, 'V> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Map<'K, 'V>> =
+        static member inline GetCodec (_: Map<'K, 'V> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Map<'K, 'V>> =
             fun () ->
                 match typeof<'K> with
                 | t when t = typeof<string> 
@@ -715,11 +719,11 @@ module Internals =
             |> CodecCache<'Operation, 'Encoding, _>.Run
         
     type GetCodec with
-        static member inline GetCodec (_: PropertyList<'a> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, PropertyList<'a>> =
+        static member inline GetCodec (_: PropertyList<'a> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, PropertyList<'a>> =
             fun () -> Codecs.propList (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)
             |> CodecCache<'Operation, 'Encoding, _>.Run
 
-        static member inline GetCodec (_: NonEmptyMap<'K, 'V> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, NonEmptyMap<'K, 'V>> =
+        static member inline GetCodec (_: NonEmptyMap<'K, 'V> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, NonEmptyMap<'K, 'V>> =
             fun () -> 
                 match typeof<'K> with
                 | t when t = typeof<string> 
@@ -727,7 +731,7 @@ module Internals =
                 | _ -> Codecs.nonEmptyMap     (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'K>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'V>)
             |> CodecCache<'Operation, 'Encoding, _>.Run
 
-        static member inline GetCodec (_: Dictionary<'K, 'V> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Dictionary<'K, 'V>> =
+        static member inline GetCodec (_: Dictionary<'K, 'V> when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, Dictionary<'K, 'V>> =
             fun () ->
                 match typeof<'K> with
                 | t when t = typeof<string> 
@@ -735,36 +739,37 @@ module Internals =
                 | _ -> Codecs.dictionary     (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'K>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'V>)
             |> CodecCache<'Operation, 'Encoding, _>.Run
         
-        static member inline GetCodec (_: ResizeArray<'a>         when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, ResizeArray<'a>>        = (fun () -> Codecs.resizeArray     (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
-        static member inline GetCodec (_: 'a Id2   when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, _, _: 'Operation)  = (Ok (Id2<'a> Unchecked.defaultof<'a>)), Map.empty
+        static member inline GetCodec (_: ResizeArray<'a>         when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, ResizeArray<'a>>        = (fun () -> Codecs.resizeArray     (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+        static member inline GetCodec (_: 'a Id2   when IEncoding<'Encoding>, _: GetCodec, _, _: 'Operation)  = (Ok (Id2<'a> Unchecked.defaultof<'a>)), Map.empty
 
-    type GetCodec with static member inline GetCodec (_: struct ('a * 'b                         ) when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b                         )> = (fun () -> Codecs.vtuple2 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>)                                                                                                                                                                                                                                                                                                                                          ) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c                    ) when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c                    )> = (fun () -> Codecs.vtuple3 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>)                                                                                                                                                                                                                                                                        ) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c * 'd               ) when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c * 'd               )> = (fun () -> Codecs.vtuple4 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>)                                                                                                                                                                                                      ) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c * 'd * 'e          ) when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c * 'd * 'e          )> = (fun () -> Codecs.vtuple5 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>)                                                                                                                                    ) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c * 'd * 'e * 'f     ) when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c * 'd * 'e * 'f     )> = (fun () -> Codecs.vtuple6 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'f>)                                                                  ) |> CodecCache<'Operation, 'Encoding, _>.Run
-    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c * 'd * 'e * 'f * 'g) when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c * 'd * 'e * 'f * 'g)> = (fun () -> Codecs.vtuple7 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'f>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'g>)) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: struct ('a * 'b                         ) when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b                         )> = (fun () -> Codecs.vtuple2 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>)                                                                                                                                                                                                                                                                                                                                          ) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c                    ) when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c                    )> = (fun () -> Codecs.vtuple3 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>)                                                                                                                                                                                                                                                                        ) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c * 'd               ) when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c * 'd               )> = (fun () -> Codecs.vtuple4 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>)                                                                                                                                                                                                      ) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c * 'd * 'e          ) when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c * 'd * 'e          )> = (fun () -> Codecs.vtuple5 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>)                                                                                                                                    ) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c * 'd * 'e * 'f     ) when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c * 'd * 'e * 'f     )> = (fun () -> Codecs.vtuple6 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'f>)                                                                  ) |> CodecCache<'Operation, 'Encoding, _>.Run
+    type GetCodec with static member inline GetCodec (_: struct ('a * 'b * 'c * 'd * 'e * 'f * 'g) when IEncoding<'Encoding>, _: GetCodec, c, _: 'Operation) : Codec<'Encoding, struct ('a * 'b * 'c * 'd * 'e * 'f * 'g)> = (fun () -> Codecs.vtuple7 (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'a>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'b>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'c>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'d>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'e>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'f>) (GetEnc.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'g>)) |> CodecCache<'Operation, 'Encoding, _>.Run
 
     type GetCodec with static member inline GetCodec (_: 't when 't : enum<_> and 't : (new : unit -> 't) and 't : struct and 't :> ValueType, _: GetCodec, c, _: 'Operation) = Codecs.enum
 
     type GetCodec with
 
         // Overload to handle user-defined interfaces
-        static member inline GetCodec (_: 'Base when 'Base :> ICodecInterface<'Base>, _: IDefault4, _, _: 'Operation) : Codec<'Encoding, 'Base> when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding) =
+        static member inline GetCodec (_: 'Base when 'Base :> ICodecInterface<'Base>, _: IDefault4, _, _: 'Operation) : Codec<'Encoding, 'Base> when IEncoding<'Encoding> =
             fun () ->
                 match CodecCollection<'Encoding, 'Base>.GetSubtypes |> NonEmptySeq.tryOfSeq with
                 | None ->
-                    match CodecCollection<AdHocEncoding, 'Base>.GetSubtypes |> NonEmptySeq.tryOfSeq with
-                    | None -> failwithf "Unexpected error: codec list is empty for interface %A to Encoding %A." typeof<'Base> typeof<'Encoding>
-                    | Some codecs ->
-                        (codecs |> map (fun (KeyValue(_, x)) -> x ()) |> choice >.> Codecs.propList Codecs.id |> Codec.upCast |> AdHocEncoding.ofIEncoding) (new 'Encoding () :> IEncoding) |> Codec.downCast<_, 'Encoding>
+                //     match CodecCollection<AdHocEncoding, 'Base>.GetSubtypes |> NonEmptySeq.tryOfSeq with
+                //     | None ->
+                        failwithf "Unexpected error: codec list is empty for interface %A to Encoding %A." typeof<'Base> typeof<'Encoding>
+                //    | Some codecs ->
+                //        (codecs |> map (fun (KeyValue(_, x)) -> x ()) |> choice >.> Codecs.propList Codecs.id |> Codec.upCast |> AdHocEncoding.ofIEncoding) (new 'Encoding () :> IEncoding) |> Codec.downCast<_, 'Encoding>
                 | Some cs -> cs |> map (fun (KeyValue(_, x)) -> x ()) |> choice >.> Codecs.propList Codecs.id
             |> CodecCache<'Operation, 'Encoding, _>.RunForInterfaces
 
     type GetCodec with
 
         // Overload to "passthrough" an IEncoding
-        static member GetCodec (_: 'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: IDefault3, _, _: 'Operation) = Codecs.id : Codec<'Encoding, 'Encoding>
+        static member GetCodec (_: 'Encoding when IEncoding<'Encoding>, _: IDefault3, _, _: 'Operation) = Codecs.id : Codec<'Encoding, 'Encoding>
     
         // Main overload for external classes
         static member inline GetCodec (_: 'T, _: IDefault3, _, _: 'Operation) : Codec<'Encoding, 'T> =
@@ -790,7 +795,7 @@ module Internals =
             |> CodecCache<'Operation, 'Encoding, 'T>.Run
 
         // For tuples
-        static member inline GetCodec (_:'tuple when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding), _: IDefault8, c, _: 'Operation) : Codec<'Encoding, _> =
+        static member inline GetCodec (_:'tuple when IEncoding<'Encoding>, _: IDefault8, c, _: 'Operation) : Codec<'Encoding, _> =
             let _f t = (^tuple: (member Item1: 't1) t)
             GetArrCodec.Invoke<'Encoding, 'Operation, _> Unchecked.defaultof<'tuple> >.> Codecs.array Codecs.id
 
@@ -857,11 +862,11 @@ module Operators =
     // Extracts a decoder and an encoder function from a Codec.
     let (|Codec|) { Decoder = ReaderT x; Encoder = y } = (x, y >> Const.run)
 
-    let inline toEncoding< 'Encoding, .. when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> (x: 't) : 'Encoding =
+    let inline toEncoding< 'Encoding, .. when IEncoding<'Encoding>> (x: 't) : 'Encoding =
         let codec = GetEnc.Invoke<'Encoding, OpEncode, _> x
         Codec.encode codec x
 
-    let inline ofEncoding (x: 'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)) : Result<'t, _> =
+    let inline ofEncoding (x: 'Encoding when IEncoding<'Encoding>) : Result<'t, _> =
         let codec = GetDec.Invoke<'Encoding, OpDecode, _> Unchecked.defaultof<'t>
         Codec.decode codec x
             
@@ -888,7 +893,7 @@ module Operators =
         <-> (fun x -> match getter x with Some (x: 'Value) -> PropertyList [| prop, Codec.encode (c ()) x |] | _ -> zero)
 
     /// Derive automatically a Codec from the type, based on GetCodec / Codec static members.
-    let inline defaultCodec<'Encoding, ^t when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding) and (GetCodec or ^t) : (static member GetCodec: ^t * GetCodec * GetCodec * OpCodec -> Codec<'Encoding, ^t>)> =
+    let inline defaultCodec<'Encoding, ^t when IEncoding<'Encoding> and (GetCodec or ^t) : (static member GetCodec: ^t * GetCodec * GetCodec * OpCodec -> Codec<'Encoding, ^t>)> =
         GetCodec.Invoke<'Encoding, OpCodec, 't> Unchecked.defaultof<'t>
 
 
@@ -933,7 +938,7 @@ module Operators =
     [<Obsolete("Use PropertyList instead.")>]
     let dictAsProps (x: IReadOnlyDictionary<string, 'Encoding>) = x |> Seq.map (|KeyValue|) |> Array.ofSeq |> PropertyList
 
-    let JNull<'Encoding when 'Encoding :> IEncoding and 'Encoding : (new : unit -> 'Encoding)> : 'Encoding = (Codecs.option Codecs.unit |> Codec.encode) None
+    let JNull<'Encoding when IEncoding<'Encoding>> : 'Encoding = (Codecs.option Codecs.unit |> Codec.encode) None
     let JBool   x = (Codecs.boolean |> Codec.encode) x
     let JNumber x = (Codecs.decimal |> Codec.encode) x
     let JString x = (Codecs.string  |> Codec.encode) x

--- a/test/IntegrationCompilationTests/IntegrationCompilationTests.fsproj
+++ b/test/IntegrationCompilationTests/IntegrationCompilationTests.fsproj
@@ -3,7 +3,7 @@
 
     <PropertyGroup>
 		<OutputType>Exe</OutputType>
-        <TargetFramework>net6</TargetFramework>
+        <TargetFramework>net7</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/IntegrationCompilationTests/Library.fs
+++ b/test/IntegrationCompilationTests/Library.fs
@@ -557,17 +557,23 @@ module TestInterfaces =
             return { Brand = brand; MaxSpeed = maxSpeed; MaxLoad = maxLoad; Extra = extra }
         }
 
+    let ivehicleObjCodec () = codec {
+        Car.ObjCodec ()   <.< ((fun (x: Car  ) -> Ok (x :> IVehicle)) <-> fun (x: IVehicle) -> x :?> Car)
+        Truck.ObjCodec () <.< ((fun (x: Truck) -> Ok (x :> IVehicle)) <-> fun (x: IVehicle) -> x :?> Truck) }
+    
     type Garage = { Vehicle : IVehicle } with
         static member get_Codec () = ofObjCodec <| codec {
-            let! v = jreq "Vehicle" (fun x -> Some x.Vehicle)
+            let! v = jreqWith (ofObjCodec (ivehicleObjCodec ()))  "Vehicle" (fun x -> Some x.Vehicle)
             return { Vehicle = v} }
     
     let car = Car (Brand = "Volvo", MaxSpeed = 120.0) :> IVehicle
     let truck =  { Brand = "Ford" ; MaxSpeed = 100.0; MaxLoad = 2500.0; Extra = (1, 2, 3, 4, 5, 6, 7, 8) } :> IVehicle
     let gcar =   { Vehicle = car }
     let gtruck = { Vehicle = truck }
+
     
-    do ICodecInterface<IVehicle>.RegisterCodec<AdHocEncoding, Car> Car.ObjCodec
+    
+    // do ICodecInterface<IVehicle>.RegisterCodec<AdHocEncoding, Car> Car.ObjCodec
 
     let stjGCarJson = Fleece.SystemTextJson.Operators.toJsonText gcar
     let stjCarJson  = Fleece.SystemTextJson.Operators.toJsonText car
@@ -577,7 +583,7 @@ module TestInterfaces =
     Assert.StringContains ("", "brand", stjCarJson)
     Assert.StringContains ("", "brand", stjGCarJson)
 
-    do ICodecInterface<IVehicle>.RegisterCodec<AdHocEncoding, Truck> Truck.ObjCodec
+    // do ICodecInterface<IVehicle>.RegisterCodec<AdHocEncoding, Truck> Truck.ObjCodec
 
     let stjGTruckJson = Fleece.SystemTextJson.Operators.toJsonText gtruck    
     let stjTruckJson  = Fleece.SystemTextJson.Operators.toJsonText truck

--- a/test/Tests.FSharpData/Tests.FSharpData.fsproj
+++ b/test/Tests.FSharpData/Tests.FSharpData.fsproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp31;net6</TargetFrameworks>
+        <TargetFrameworks>net7</TargetFrameworks>
         <DefineConstants>FSHARPDATA;$(DefineConstants)</DefineConstants>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
This will take advantage of static interfaces, which is the natural way of conding the `IEncoding` interface.

The question is what do we do with codec for interfaces which uses Ad-Hoc Encoding which relied in an instance to call the interface methods.