### PR TITLE
Use obj for Errors as opposed to IEncoding

### DIFF
--- a/src/Fleece/Compatibility.fs
+++ b/src/Fleece/Compatibility.fs
@@ -128,9 +128,9 @@ module Operators =
                     match (Codecs.array (Ok <-> id) |> Codec.decode) x with
                     | Ok a -> a
                     | Error x -> failwithf "Error on error handling: Expected an 'Encoding [] but received %A." x
-                Error (IndexOutOfRange (e, map (fun x -> x :> IEncoding) a))
+                Error (IndexOutOfRange (e, map (fun x -> x :> obj) a))
             let invalidValue (v: 'Encoding) o : Result<'t, _> = Error (InvalidValue (typeof<'t>, v, o))
-            let propertyNotFound p (o: PropertyList<'Encoding>) = Error (PropertyNotFound (p, map (fun x -> x :> IEncoding) o))
+            let propertyNotFound p (o: PropertyList<'Encoding>) = Error (PropertyNotFound (p, map (fun x -> x :> obj) o))
             let parseError s v : Result<'t, _> = Error (ParseError (typeof<'t>, s, v))
 
     


### PR DESCRIPTION
Using `IEncoding` to store information in errors makes almost the whole DU useless for codecs that don't use IEncoding, ie string codecs.